### PR TITLE
update codecs parameter to latest spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -366,7 +366,7 @@ Codecs Parameter String {#codecsparam}
 
 DASH and other applications require defined values for the 'Codecs' parameter specified in [[!RFC6381]] for ISO Media tracks. The codecs parameter string for the AOM AV1 codec is as follows:
 ```
-<sample entry 4CC>.<profile>.<level>.<bitDepth>.<monochrome>.<chromaSubsampling>.
+<sample entry 4CC>.<profile>.<still>.<level>.<bitDepth>.<monochrome>.<chromaSubsampling>.
 <colourPrimaries>.<transferCharacteristics>.<matrixCoefficients>.
 <videoFullRangeFlag>
 ```
@@ -375,7 +375,9 @@ All fields following the sample entry 4CC are expressed as double digit decimals
 
 The profile parameter value, represented by a single digit decimal, SHALL equal the value of seq_profile in the [=Sequence Header=].
 
-The level parameter value SHALL equal the value of level in the [=Sequence Header=] for one of the operating point.
+The still parameter value, represented by a single digit decimal, SHALL equal the value of still_picture in the [=Sequence Header=].
+
+The level parameter value SHALL equal the first level value in the [=Sequence Header=].
 
 The bitDepth parameter value SHALL equal the value of BitDepth variable as defined in [[AV1]] derived from the [=Sequence Header=].
 
@@ -383,13 +385,13 @@ The monochrome parameter value, represented by a single digit decimal, SHALL equ
 
 The chromaSubsampling parameter value, represented by a three-digit decimal, SHALL have its first digit equal to subsampling_x and its second digit equal to subsampling_y and the third digit equal to chroma_sample_position, if the first two values are non-zero, or 0 otheriwise.
 
-The colourPrimaries, transferCharacteristics, matrixCoefficients and videoFullRangeFlag parameter values SHALL equal the value of matching fields in the [=Sequence Header=], if color_description_present_flag is set to 1, otherwise the fields can take any value.
+The colourPrimaries, transferCharacteristics, matrixCoefficients and videoFullRangeFlag parameter values SHALL equal the value of matching fields in the [=Sequence Header=], if color_description_present_flag is set to 1, otherwise they SHOULD not be set, defaulting to the values below. The videoFullRangeFlag is represented by a single digit.
 
-For example, codecs="av01.2.01.10.0.112.09.16.09.01" represents AV1 profile 2, level 1, 10-bit YUV content, non-monochrome, with 4:2:0 chroma subsampling, ITU-R BT.2020 primaries, ST 2084 EOTF, ITU-R BT.2020 non-constant luminance color matrix, and full-range chroma/luma encoding.
+For example, codecs="av01.2.0.01.10.0.112.09.16.09.1" represents AV1 profile 2, level 1, 10-bit YUV content, non-monochrome, with 4:2:0 chroma subsampling, ITU-R BT.2020 primaries, ST 2084 EOTF, ITU-R BT.2020 non-constant luminance color matrix, and full-range chroma/luma encoding.
 
 The parameters sample entry 4CC, profile, level, and bitDepth are all mandatory fields. If any of these fields are empty, or not within their allowed range, the processing device SHOULD treat it as an error.
 
-All the other fields are optional, mutually inclusive (all or none) fields. If not specified then the values listed in the table below are assumed and SHALL match the value in the bitstream.
+All the other fields (including their leading '.') are optional, mutually inclusive (all or none) fields. If not specified then the values listed in the table below are assumed and SHALL match the value in the bitstream.
 
 <table class="def">
 <tr>
@@ -412,4 +414,6 @@ All the other fields are optional, mutually inclusive (all or none) fields. If n
 </tr>
 </table>
 
-The string codecs="av01.01.01.08" in this case would represent AV1 profile 1, level 1, 8-bit YUV content with 4:2:0 chroma subsampling, ITU-R BT.709 color primaries, transfer function and matrix coefficients, and luma/chroma encoded in the "limited" range.
+The string codecs="av01.1.0.01.08" in this case would represent AV1 profile 1, level 1, 8-bit YUV content with 4:2:0 chroma subsampling, ITU-R BT.709 color primaries, transfer function and matrix coefficients, and luma/chroma encoded in the "limited" range.
+
+If any character that is not '.' or digits is encountered, the string SHALL be interpreted ignoring all the characters starting from that character.

--- a/index.bs
+++ b/index.bs
@@ -387,7 +387,7 @@ The chromaSubsampling parameter value, represented by a three-digit decimal, SHA
 
 The colourPrimaries, transferCharacteristics, matrixCoefficients and videoFullRangeFlag parameter values SHALL equal the value of matching fields in the [=Sequence Header=], if color_description_present_flag is set to 1, otherwise they SHOULD not be set, defaulting to the values below. The videoFullRangeFlag is represented by a single digit.
 
-For example, codecs="av01.2.0.01.10.0.112.09.16.09.1" represents AV1 profile 2, level 1, 10-bit YUV content, non-monochrome, with 4:2:0 chroma subsampling, ITU-R BT.2020 primaries, ST 2084 EOTF, ITU-R BT.2020 non-constant luminance color matrix, and full-range chroma/luma encoding.
+For example, codecs="av01.2.0.01.10.0.112.09.16.09.1" represents AV1 profile 2, non still picture mode, level 1, 10-bit YUV content, non-monochrome, with 4:2:0 chroma subsampling, ITU-R BT.2020 primaries, ST 2084 EOTF, ITU-R BT.2020 non-constant luminance color matrix, and full-range chroma/luma encoding.
 
 The parameters sample entry 4CC, profile, level, and bitDepth are all mandatory fields. If any of these fields are empty, or not within their allowed range, the processing device SHOULD treat it as an error.
 
@@ -414,6 +414,6 @@ All the other fields (including their leading '.') are optional, mutually inclus
 </tr>
 </table>
 
-The string codecs="av01.1.0.01.08" in this case would represent AV1 profile 1, level 1, 8-bit YUV content with 4:2:0 chroma subsampling, ITU-R BT.709 color primaries, transfer function and matrix coefficients, and luma/chroma encoded in the "limited" range.
+The string codecs="av01.1.0.01.08" in this case would represent AV1 profile 1, non still picture mode, level 1, 8-bit YUV content with 4:2:0 chroma subsampling, ITU-R BT.709 color primaries, transfer function and matrix coefficients, and luma/chroma encoded in the "limited" range.
 
 If any character that is not '.' or digits is encountered, the string SHALL be interpreted ignoring all the characters starting from that character.

--- a/index.html
+++ b/index.html
@@ -1178,7 +1178,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 67155cabad72a8ab669a7d4421c90e2999a29b68" name="generator">
   <link href="https://AOMediaCodec.github.io/av1-isobmff" rel="canonical">
-  <meta content="69ac66639b76719dfecb0898c6da948639558794" name="document-revision">
+  <meta content="34e058ea50562220b8485916597f5a0214ee85e6" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1749,20 +1749,21 @@ aligned (8) class AV1CodecConfigurationRecord {
    </figure>
    <h2 class="heading settled" data-level="5" id="codecsparam"><span class="secno">5. </span><span class="content">Codecs Parameter String</span><a class="self-link" href="#codecsparam"></a></h2>
    <p>DASH and other applications require defined values for the <a class="property" data-link-type="propdesc" href="#http://iso.org" id="ref-for-http://iso.org②②">Codecs</a> parameter specified in <a data-link-type="biblio" href="#biblio-rfc6381">[RFC6381]</a> for ISO Media tracks. The codecs parameter string for the AOM AV1 codec is as follows:</p>
-<pre>&lt;sample entry 4CC>.&lt;profile>.&lt;level>.&lt;bitDepth>.&lt;monochrome>.&lt;chromaSubsampling>.
+<pre>&lt;sample entry 4CC>.&lt;profile>.&lt;still>.&lt;level>.&lt;bitDepth>.&lt;monochrome>.&lt;chromaSubsampling>.
 &lt;colourPrimaries>.&lt;transferCharacteristics>.&lt;matrixCoefficients>.
 &lt;videoFullRangeFlag>
 </pre>
    <p>All fields following the sample entry 4CC are expressed as double digit decimals, unless indicated otherwise. Leading or trailing zeros cannot be omitted.</p>
    <p>The profile parameter value, represented by a single digit decimal, SHALL equal the value of seq_profile in the <a data-link-type="dfn" href="#AOMediaCodec/av1-spec" id="ref-for-AOMediaCodec/av1-spec③③">Sequence Header</a>.</p>
-   <p>The level parameter value SHALL equal the value of level in the <a data-link-type="dfn" href="#AOMediaCodec/av1-spec" id="ref-for-AOMediaCodec/av1-spec③④">Sequence Header</a> for one of the operating point.</p>
-   <p>The bitDepth parameter value SHALL equal the value of BitDepth variable as defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> derived from the <a data-link-type="dfn" href="#AOMediaCodec/av1-spec" id="ref-for-AOMediaCodec/av1-spec③⑤">Sequence Header</a>.</p>
-   <p>The monochrome parameter value, represented by a single digit decimal, SHALL equal the value of mono_chrome in the <a data-link-type="dfn" href="#AOMediaCodec/av1-spec" id="ref-for-AOMediaCodec/av1-spec③⑥">Sequence Header</a>.</p>
+   <p>The still parameter value, represented by a single digit decimal, SHALL equal the value of still_picture in the <a data-link-type="dfn" href="#AOMediaCodec/av1-spec" id="ref-for-AOMediaCodec/av1-spec③④">Sequence Header</a>.</p>
+   <p>The level parameter value SHALL equal the first level value in the <a data-link-type="dfn" href="#AOMediaCodec/av1-spec" id="ref-for-AOMediaCodec/av1-spec③⑤">Sequence Header</a>.</p>
+   <p>The bitDepth parameter value SHALL equal the value of BitDepth variable as defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> derived from the <a data-link-type="dfn" href="#AOMediaCodec/av1-spec" id="ref-for-AOMediaCodec/av1-spec③⑥">Sequence Header</a>.</p>
+   <p>The monochrome parameter value, represented by a single digit decimal, SHALL equal the value of mono_chrome in the <a data-link-type="dfn" href="#AOMediaCodec/av1-spec" id="ref-for-AOMediaCodec/av1-spec③⑦">Sequence Header</a>.</p>
    <p>The chromaSubsampling parameter value, represented by a three-digit decimal, SHALL have its first digit equal to subsampling_x and its second digit equal to subsampling_y and the third digit equal to chroma_sample_position, if the first two values are non-zero, or 0 otheriwise.</p>
-   <p>The colourPrimaries, transferCharacteristics, matrixCoefficients and videoFullRangeFlag parameter values SHALL equal the value of matching fields in the <a data-link-type="dfn" href="#AOMediaCodec/av1-spec" id="ref-for-AOMediaCodec/av1-spec③⑦">Sequence Header</a>, if color_description_present_flag is set to 1, otherwise the fields can take any value.</p>
-   <p>For example, codecs="av01.2.01.10.0.112.09.16.09.01" represents AV1 profile 2, level 1, 10-bit YUV content, non-monochrome, with 4:2:0 chroma subsampling, ITU-R BT.2020 primaries, ST 2084 EOTF, ITU-R BT.2020 non-constant luminance color matrix, and full-range chroma/luma encoding.</p>
+   <p>The colourPrimaries, transferCharacteristics, matrixCoefficients and videoFullRangeFlag parameter values SHALL equal the value of matching fields in the <a data-link-type="dfn" href="#AOMediaCodec/av1-spec" id="ref-for-AOMediaCodec/av1-spec③⑧">Sequence Header</a>, if color_description_present_flag is set to 1, otherwise they SHOULD not be set, defaulting to the values below. The videoFullRangeFlag is represented by a single digit.</p>
+   <p>For example, codecs="av01.2.0.01.10.0.112.09.16.09.1" represents AV1 profile 2, level 1, 10-bit YUV content, non-monochrome, with 4:2:0 chroma subsampling, ITU-R BT.2020 primaries, ST 2084 EOTF, ITU-R BT.2020 non-constant luminance color matrix, and full-range chroma/luma encoding.</p>
    <p>The parameters sample entry 4CC, profile, level, and bitDepth are all mandatory fields. If any of these fields are empty, or not within their allowed range, the processing device SHOULD treat it as an error.</p>
-   <p>All the other fields are optional, mutually inclusive (all or none) fields. If not specified then the values listed in the table below are assumed and SHALL match the value in the bitstream.</p>
+   <p>All the other fields (including their leading '.') are optional, mutually inclusive (all or none) fields. If not specified then the values listed in the table below are assumed and SHALL match the value in the bitstream.</p>
    <table class="def">
     <tbody>
      <tr>
@@ -1784,7 +1785,8 @@ aligned (8) class AV1CodecConfigurationRecord {
       <td>videoFullRangeFlag
       <td>0 (limited range)
    </table>
-   <p>The string codecs="av01.01.01.08" in this case would represent AV1 profile 1, level 1, 8-bit YUV content with 4:2:0 chroma subsampling, ITU-R BT.709 color primaries, transfer function and matrix coefficients, and luma/chroma encoded in the "limited" range.</p>
+   <p>The string codecs="av01.1.0.01.08" in this case would represent AV1 profile 1, level 1, 8-bit YUV content with 4:2:0 chroma subsampling, ITU-R BT.709 color primaries, transfer function and matrix coefficients, and luma/chroma encoded in the "limited" range.</p>
+   <p>If any character that is not '.' or digits is encountered, the string SHALL be interpreted ignoring all the characters starting from that character.</p>
   </main>
   <div data-fill-with="conformance">
    <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>

--- a/index.html
+++ b/index.html
@@ -1178,7 +1178,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 67155cabad72a8ab669a7d4421c90e2999a29b68" name="generator">
   <link href="https://AOMediaCodec.github.io/av1-isobmff" rel="canonical">
-  <meta content="34e058ea50562220b8485916597f5a0214ee85e6" name="document-revision">
+  <meta content="685bba9d657729d75b1b5061ea2cbffc0d294589" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1761,7 +1761,7 @@ aligned (8) class AV1CodecConfigurationRecord {
    <p>The monochrome parameter value, represented by a single digit decimal, SHALL equal the value of mono_chrome in the <a data-link-type="dfn" href="#AOMediaCodec/av1-spec" id="ref-for-AOMediaCodec/av1-spec③⑦">Sequence Header</a>.</p>
    <p>The chromaSubsampling parameter value, represented by a three-digit decimal, SHALL have its first digit equal to subsampling_x and its second digit equal to subsampling_y and the third digit equal to chroma_sample_position, if the first two values are non-zero, or 0 otheriwise.</p>
    <p>The colourPrimaries, transferCharacteristics, matrixCoefficients and videoFullRangeFlag parameter values SHALL equal the value of matching fields in the <a data-link-type="dfn" href="#AOMediaCodec/av1-spec" id="ref-for-AOMediaCodec/av1-spec③⑧">Sequence Header</a>, if color_description_present_flag is set to 1, otherwise they SHOULD not be set, defaulting to the values below. The videoFullRangeFlag is represented by a single digit.</p>
-   <p>For example, codecs="av01.2.0.01.10.0.112.09.16.09.1" represents AV1 profile 2, level 1, 10-bit YUV content, non-monochrome, with 4:2:0 chroma subsampling, ITU-R BT.2020 primaries, ST 2084 EOTF, ITU-R BT.2020 non-constant luminance color matrix, and full-range chroma/luma encoding.</p>
+   <p>For example, codecs="av01.2.0.01.10.0.112.09.16.09.1" represents AV1 profile 2, non still picture mode, level 1, 10-bit YUV content, non-monochrome, with 4:2:0 chroma subsampling, ITU-R BT.2020 primaries, ST 2084 EOTF, ITU-R BT.2020 non-constant luminance color matrix, and full-range chroma/luma encoding.</p>
    <p>The parameters sample entry 4CC, profile, level, and bitDepth are all mandatory fields. If any of these fields are empty, or not within their allowed range, the processing device SHOULD treat it as an error.</p>
    <p>All the other fields (including their leading '.') are optional, mutually inclusive (all or none) fields. If not specified then the values listed in the table below are assumed and SHALL match the value in the bitstream.</p>
    <table class="def">
@@ -1785,7 +1785,7 @@ aligned (8) class AV1CodecConfigurationRecord {
       <td>videoFullRangeFlag
       <td>0 (limited range)
    </table>
-   <p>The string codecs="av01.1.0.01.08" in this case would represent AV1 profile 1, level 1, 8-bit YUV content with 4:2:0 chroma subsampling, ITU-R BT.709 color primaries, transfer function and matrix coefficients, and luma/chroma encoded in the "limited" range.</p>
+   <p>The string codecs="av01.1.0.01.08" in this case would represent AV1 profile 1, non still picture mode, level 1, 8-bit YUV content with 4:2:0 chroma subsampling, ITU-R BT.709 color primaries, transfer function and matrix coefficients, and luma/chroma encoded in the "limited" range.</p>
    <p>If any character that is not '.' or digits is encountered, the string SHALL be interpreted ignoring all the characters starting from that character.</p>
   </main>
   <div data-fill-with="conformance">


### PR DESCRIPTION
Related to #9 
- add still_picture field
- clarify that first operating point is used
- add support for extensibility if we want to add other operating points.