### PR TITLE
Initial presentation delay updates.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -200,7 +200,7 @@ The <dfn>initial_presentation_delay_minus_one</dfn> field indicates the number o
 - set the [=frame_presentation_delay=] field of the frame header of each presentable frame such that it matches the presentation time difference between the sample carrying this frame and the previous sample (if it exists, 0 otherwise)
 - apply the display model verification algorithm.
 
-When smooth presentation can be guaranteed after decoding the first sample, the value 0 SHALL be used. If an ISOBMFF writer cannot verify the above procedure, [=initial_presentation_delay=] SHOULD be set to its maximum value.
+When smooth presentation can be guaranteed after decoding the first sample, the value 0 SHALL be used. If an ISOBMFF writer cannot verify the above procedure, [=initial_presentation_delay_present=] SHALL be set to 0.
 
 The presentation times of AV1 samples are given by the ISOBMFF structures. The [=timing_info_present_flag=] in the [=Sequence Header=] (in the configOBUs field or in the associated samples) SHOULD be set to 0. If set to 1, the [=timing_info=] structure of the [=Sequence Header=], the [=frame_presentation_delay=] and [=buffer_removal_delay=] fields of the [=Frame Headers=], if present, SHALL be ignored for the purpose of timed processing of the ISOBMFF file.
 

--- a/index.bs
+++ b/index.bs
@@ -171,8 +171,13 @@ class AV1CodecConfigurationBox extends FullBox('av1C', version = 0, 0){
 }
 
 aligned (8) class AV1CodecConfigurationRecord {
-  unsigned int (4) reserved = 0;
-  unsigned int (4) initial_presentation_delay_minus_one;
+  unsigned int (3) reserved = 0;
+  unsigned int (1) initial_presentation_delay_present;
+  if (initial_presentation_delay_present) {
+    unsigned int (4) initial_presentation_delay_minus_one;
+  } else {
+    unsigned int (4) reserved;
+  }
   unsigned int (8)[] configOBUs;
 }
 ```
@@ -186,6 +191,8 @@ The <dfn>configOBUs</dfn> field contains zero or more OBUs. Any OBU may be prese
 NOTE: The configOBUs field is expected to contain only OBU_SEQUENCE_HEADER and OBU_METADATA when the metadata is applicable to all the associated samples.
 
 OBUs stored in the configOBUs field follow the [=open_bitstream_unit=] [=Low Overhead Bitstream Format=] syntax as specified in [[!AV1]]. The flag [=obu_has_size_field=] SHALL be set to 1, indicating that the size of the OBU payload follows the header, and that it is coded using LEB128.
+
+The <dfn>initial_presentation_delay_present</dfn> field indicates the presence of the initial_presentation_delay_minus_one field.
 
 The <dfn>initial_presentation_delay_minus_one</dfn> field indicates the number of samples (minus one) that need be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by [=seq_level_idx=] in the [=Sequence Header=] (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:
 - construct a hypothetical bitstream consisting of the OBUs carried in the sample entry followed by the OBUs carried in all the samples,

--- a/index.bs
+++ b/index.bs
@@ -171,8 +171,8 @@ class AV1CodecConfigurationBox extends FullBox('av1C', version = 0, 0){
 }
 
 aligned (8) class AV1CodecConfigurationRecord {
-  unsigned int (5) reserved = 0;
-  unsigned int (3) initial_presentation_delay_minus_one;
+  unsigned int (4) reserved = 0;
+  unsigned int (4) initial_presentation_delay_minus_one;
   unsigned int (8)[] configOBUs;
 }
 ```

--- a/index.html
+++ b/index.html
@@ -1211,9 +1211,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 3f684c5a8b9e82482490404d25c7ed75e25b2c98" name="generator">
+  <meta content="Bikeshed version 0e8880531a1904b4bc0b037759fa3cb386293992" name="generator">
   <link href="https://AOMediaCodec.github.io/av1-isobmff" rel="canonical">
-  <meta content="e29fc43cf1b2669fe4e825cc452df3e6257fa1f8" name="document-revision">
+  <meta content="67d81d2ad651ec33f2b71467782ce8415d7020eb" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1602,7 +1602,7 @@ aligned (8) class AV1CodecConfigurationRecord {
    </ul>
    <p class="note" role="note"><span>NOTE:</span> The configOBUs field is expected to contain only OBU_SEQUENCE_HEADER and OBU_METADATA when the metadata is applicable to all the associated samples.</p>
    <p>OBUs stored in the configOBUs field follow the <a data-link-type="dfn">open_bitstream_unit</a> <a data-link-type="dfn" href="#https://aomediacodec.github.io/av1-spec/av1-spec.pdf" id="ref-for-https://aomediacodec.github.io/av1-spec/av1-spec.pdf②④">Low Overhead Bitstream Format</a> syntax as specified in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>. The flag <a data-link-type="dfn" href="#https://aomediacodec.github.io/av1-spec/av1-spec.pdf" id="ref-for-https://aomediacodec.github.io/av1-spec/av1-spec.pdf②⑤">obu_has_size_field</a> SHALL be set to 1, indicating that the size of the OBU payload follows the header, and that it is coded using LEB128.</p>
-   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="initial_presentation_delay_present">initial_presentation_delay_present<a class="self-link" href="#initial_presentation_delay_present"></a></dfn> field indicates the presence of the initial_presentation_delay_minus_one field.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="initial_presentation_delay_present">initial_presentation_delay_present</dfn> field indicates the presence of the initial_presentation_delay_minus_one field.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</dfn> field indicates the number of samples (minus one) that need be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by <a data-link-type="dfn" href="#https://aomediacodec.github.io/av1-spec/av1-spec.pdf" id="ref-for-https://aomediacodec.github.io/av1-spec/av1-spec.pdf②⑥">seq_level_idx</a> in the <a data-link-type="dfn" href="#https://aomediacodec.github.io/av1-spec/av1-spec.pdf" id="ref-for-https://aomediacodec.github.io/av1-spec/av1-spec.pdf②⑦">Sequence Header</a> (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:</p>
    <ul>
     <li data-md="">
@@ -1614,7 +1614,7 @@ aligned (8) class AV1CodecConfigurationRecord {
     <li data-md="">
      <p>apply the display model verification algorithm.</p>
    </ul>
-   <p>When smooth presentation can be guaranteed after decoding the first sample, the value 0 SHALL be used. If an ISOBMFF writer cannot verify the above procedure, <a data-link-type="dfn">initial_presentation_delay</a> SHOULD be set to its maximum value.</p>
+   <p>When smooth presentation can be guaranteed after decoding the first sample, the value 0 SHALL be used. If an ISOBMFF writer cannot verify the above procedure, <a data-link-type="dfn" href="#initial_presentation_delay_present" id="ref-for-initial_presentation_delay_present">initial_presentation_delay_present</a> SHALL be set to 0.</p>
    <p>The presentation times of AV1 samples are given by the ISOBMFF structures. The <a data-link-type="dfn">timing_info_present_flag</a> in the <a data-link-type="dfn" href="#https://aomediacodec.github.io/av1-spec/av1-spec.pdf" id="ref-for-https://aomediacodec.github.io/av1-spec/av1-spec.pdf③①">Sequence Header</a> (in the configOBUs field or in the associated samples) SHOULD be set to 0. If set to 1, the <a data-link-type="dfn" href="#https://aomediacodec.github.io/av1-spec/av1-spec.pdf" id="ref-for-https://aomediacodec.github.io/av1-spec/av1-spec.pdf③②">timing_info</a> structure of the <a data-link-type="dfn" href="#https://aomediacodec.github.io/av1-spec/av1-spec.pdf" id="ref-for-https://aomediacodec.github.io/av1-spec/av1-spec.pdf③③">Sequence Header</a>, the <a data-link-type="dfn" href="#https://aomediacodec.github.io/av1-spec/av1-spec.pdf" id="ref-for-https://aomediacodec.github.io/av1-spec/av1-spec.pdf③④">frame_presentation_delay</a> and <a data-link-type="dfn" href="#https://aomediacodec.github.io/av1-spec/av1-spec.pdf" id="ref-for-https://aomediacodec.github.io/av1-spec/av1-spec.pdf③⑤">buffer_removal_delay</a> fields of the <a data-link-type="dfn" href="#https://aomediacodec.github.io/av1-spec/av1-spec.pdf" id="ref-for-https://aomediacodec.github.io/av1-spec/av1-spec.pdf③⑥">Frame Headers</a>, if present, SHALL be ignored for the purpose of timed processing of the ISOBMFF file.</p>
    <p>If a <a class="property" data-link-type="propdesc" href="#http://iso.org" id="ref-for-http://iso.org⑦">colr</a> box is present in the <a data-link-type="dfn" href="#http://iso.org" id="ref-for-http://iso.org⑧">VisualSampleEntry</a> with a colour_type set to <a class="property" data-link-type="propdesc">nclx</a>, the values of colour_primaries, transfer_characteristics, and matrix_coefficients SHALL match the values given in the <a data-link-type="dfn" href="#https://aomediacodec.github.io/av1-spec/av1-spec.pdf" id="ref-for-https://aomediacodec.github.io/av1-spec/av1-spec.pdf③⑦">Sequence Header</a> (in the configOBUs field or in the associated samples) if the color_description_present_flag is set to 1. Similarly, the full_range_flag in the <a class="property" data-link-type="propdesc" href="#http://iso.org" id="ref-for-http://iso.org⑨">colr</a> box shall match the color_range flag in the <a data-link-type="dfn" href="#https://aomediacodec.github.io/av1-spec/av1-spec.pdf" id="ref-for-https://aomediacodec.github.io/av1-spec/av1-spec.pdf③⑧">Sequence Header</a>.</p>
    <p>Additional boxes may be provided at the end of the <a data-link-type="dfn" href="#http://iso.org" id="ref-for-http://iso.org①⓪">VisualSampleEntry</a> as permitted by ISOBMFF, that may represent redundant or similar information to the one provided in some OBUs contained in the <a data-link-type="dfn">AV1CodecConfigurationRecord</a>. If the box definition does not indicate that its information overrides the OBU information, in case of conflict, the OBU information should be considered authoritative.</p>
@@ -2264,6 +2264,12 @@ aligned (8) class AV1CodecConfigurationRecord {
     <li><a href="#ref-for-av1codecconfigurationbox">2.3.2. Description</a>
     <li><a href="#ref-for-av1codecconfigurationbox①">2.3.4. Semantics</a>
     <li><a href="#ref-for-av1codecconfigurationbox②">2.4.4. Semantics</a> <a href="#ref-for-av1codecconfigurationbox③">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="initial_presentation_delay_present">
+   <b><a href="#initial_presentation_delay_present">#initial_presentation_delay_present</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-initial_presentation_delay_present">2.4.4. Semantics</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="initial_presentation_delay_minus_one">

--- a/index.html
+++ b/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 3f684c5a8b9e82482490404d25c7ed75e25b2c98" name="generator">
   <link href="https://AOMediaCodec.github.io/av1-isobmff" rel="canonical">
-  <meta content="821ffcdaa7f7bea55a72ae63ca57a82c984988a2" name="document-revision">
+  <meta content="e29fc43cf1b2669fe4e825cc452df3e6257fa1f8" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1582,8 +1582,13 @@ pre .property::before, pre .property::after {
 }
 
 aligned (8) class AV1CodecConfigurationRecord {
-  unsigned int (5) reserved = 0;
-  unsigned int (3) initial_presentation_delay_minus_one;
+  unsigned int (3) reserved = 0;
+  unsigned int (1) initial_presentation_delay_present;
+  if (initial_presentation_delay_present) {
+    unsigned int (4) initial_presentation_delay_minus_one;
+  } else {
+    unsigned int (4) reserved;
+  }
   unsigned int (8)[] configOBUs;
 }
 </pre>
@@ -1597,6 +1602,7 @@ aligned (8) class AV1CodecConfigurationRecord {
    </ul>
    <p class="note" role="note"><span>NOTE:</span> The configOBUs field is expected to contain only OBU_SEQUENCE_HEADER and OBU_METADATA when the metadata is applicable to all the associated samples.</p>
    <p>OBUs stored in the configOBUs field follow the <a data-link-type="dfn">open_bitstream_unit</a> <a data-link-type="dfn" href="#https://aomediacodec.github.io/av1-spec/av1-spec.pdf" id="ref-for-https://aomediacodec.github.io/av1-spec/av1-spec.pdf②④">Low Overhead Bitstream Format</a> syntax as specified in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>. The flag <a data-link-type="dfn" href="#https://aomediacodec.github.io/av1-spec/av1-spec.pdf" id="ref-for-https://aomediacodec.github.io/av1-spec/av1-spec.pdf②⑤">obu_has_size_field</a> SHALL be set to 1, indicating that the size of the OBU payload follows the header, and that it is coded using LEB128.</p>
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="initial_presentation_delay_present">initial_presentation_delay_present<a class="self-link" href="#initial_presentation_delay_present"></a></dfn> field indicates the presence of the initial_presentation_delay_minus_one field.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</dfn> field indicates the number of samples (minus one) that need be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by <a data-link-type="dfn" href="#https://aomediacodec.github.io/av1-spec/av1-spec.pdf" id="ref-for-https://aomediacodec.github.io/av1-spec/av1-spec.pdf②⑥">seq_level_idx</a> in the <a data-link-type="dfn" href="#https://aomediacodec.github.io/av1-spec/av1-spec.pdf" id="ref-for-https://aomediacodec.github.io/av1-spec/av1-spec.pdf②⑦">Sequence Header</a> (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:</p>
    <ul>
     <li data-md="">
@@ -2030,6 +2036,7 @@ aligned (8) class AV1CodecConfigurationRecord {
    <li><a href="#fwd_distance">fwd_distance</a><span>, in §2.6.4</span>
    <li><a href="#height">height</a><span>, in §2.3.4</span>
    <li><a href="#initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</a><span>, in §2.4.4</span>
+   <li><a href="#initial_presentation_delay_present">initial_presentation_delay_present</a><span>, in §2.4.4</span>
    <li><a href="#metadata_type">metadata_type</a><span>, in §2.9.4</span>
    <li><a href="#width">width</a><span>, in §2.3.4</span>
   </ul>


### PR DESCRIPTION
A couple small changes:
1) initial_display_delay_minus_1 in the latest buffer model proposal is 4 bits.
I've updated the field in the sample entry to use 4 bits.
2) Add initial_presentation_delay_present flag.
