### PR TITLE
adding tier in codecs parameter

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -72,6 +72,7 @@ url: https://aomediacodec.github.io/av1-spec/av1-spec.pdf#; spec: AV1; type: dfn
 	text: timing_info
 	text: buffer_removal_delay
 	text: seq_level_idx
+	text: seq_tier
 	text: open_bitstream_unit
 	text: timing_info_present_flag
 </pre>
@@ -419,7 +420,7 @@ Codecs Parameter String {#codecsparam}
 
 DASH and other applications require defined values for the 'Codecs' parameter specified in [[!RFC6381]] for ISO Media tracks. The codecs parameter string for the AOM AV1 codec is as follows:
 ```
-<sample entry 4CC>.<profile>.<still>.<level>.<bitDepth>.<monochrome>.<chromaSubsampling>.
+<sample entry 4CC>.<profile>.<still>.<level><tier>.<bitDepth>.<monochrome>.<chromaSubsampling>.
 <colorPrimaries>.<transferCharacteristics>.<matrixCoefficients>.<videoFullRangeFlag>
 ```
 
@@ -431,6 +432,8 @@ The still parameter value, represented by a single digit decimal, SHALL equal th
 
 The level parameter value SHALL equal the first level value indicated by [=seq_level_idx=] in the [=Sequence Header=].
 
+The tier parameter value SHALL be equal to <code>M</code> when the first [=seq_tier=] value in the [=Sequence Header=] is equal to 0, and <code>H</code> when it is equal to 1.
+
 The bitDepth parameter value SHALL equal the value of BitDepth variable as defined in [[AV1]] derived from the [=Sequence Header=].
 
 The monochrome parameter value, represented by a single digit decimal, SHALL equal the value of mono_chrome in the [=Sequence Header=].
@@ -439,7 +442,7 @@ The chromaSubsampling parameter value, represented by a three-digit decimal, SHA
 
 The colorPrimaries, transferCharacteristics, matrixCoefficients and videoFullRangeFlag parameter values SHALL equal the value of matching fields in the [=Sequence Header=], if color_description_present_flag is set to 1, otherwise they SHOULD not be set, defaulting to the values below. The videoFullRangeFlag is represented by a single digit.
 
-For example, codecs="av01.0.0.04.10.0.112.09.16.09.0" represents AV1 profile 0, non still picture mode, level 4, 10-bit content, non-monochrome, with 4:2:0 chroma subsampling, ITU-R BT.2100 color primaries, ITU BT.2100 PQ transfer characteristics, ITU-R BT.2100 YCbCr color matrix, and studio swing representation.
+For example, codecs="av01.0.0.04M.10.0.112.09.16.09.0" represents AV1 profile 0, non still picture mode, level 4, Main tier, 10-bit content, non-monochrome, with 4:2:0 chroma subsampling, ITU-R BT.2100 color primaries, ITU BT.2100 PQ transfer characteristics, ITU-R BT.2100 YCbCr color matrix, and studio swing representation.
 
 The parameters sample entry 4CC, profile, level, and bitDepth are all mandatory fields. If any of these fields are empty, or not within their allowed range, the processing device SHOULD treat it as an error.
 
@@ -466,6 +469,6 @@ All the other fields (including their leading '.') are optional, mutually inclus
 </tr>
 </table>
 
-The string codecs="av01.0.0.01.08" in this case would represent AV1 profile 0, non still picture mode, level 1, 8-bit content with 4:2:0 chroma subsampling, ITU-R BT.709 color primaries, transfer characteristics and matrix coefficients, and studio swing representation.
+The string codecs="av01.0.0.01M.08" in this case would represent AV1 profile 0, non still picture mode, level 1, Main tier, 8-bit content with 4:2:0 chroma subsampling, ITU-R BT.709 color primaries, transfer characteristics and matrix coefficients, and studio swing representation.
 
 If any character that is not '.' or digits is encountered, the string SHALL be interpreted ignoring all the characters starting from that character.

--- a/index.html
+++ b/index.html
@@ -1211,9 +1211,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 3f684c5a8b9e82482490404d25c7ed75e25b2c98" name="generator">
+  <meta content="Bikeshed version dc6a0999286e5dda761ab3caeb4f978c270ddaf8" name="generator">
   <link href="https://AOMediaCodec.github.io/av1-isobmff" rel="canonical">
-  <meta content="8f73d4ce346d190e673f14a341769c7c4d6f0bb8" name="document-revision">
+  <meta content="829063cc7de3b58e71e00f67ab1a8ee73f2dc8ea" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1769,18 +1769,19 @@ Quantity:   Zero or more.
    </figure>
    <h2 class="heading settled" data-level="5" id="codecsparam"><span class="secno">5. </span><span class="content">Codecs Parameter String</span><a class="self-link" href="#codecsparam"></a></h2>
    <p>DASH and other applications require defined values for the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑧②">Codecs</a> parameter specified in <a data-link-type="biblio" href="#biblio-rfc6381">[RFC6381]</a> for ISO Media tracks. The codecs parameter string for the AOM AV1 codec is as follows:</p>
-<pre>&lt;sample entry 4CC>.&lt;profile>.&lt;still>.&lt;level>.&lt;bitDepth>.&lt;monochrome>.&lt;chromaSubsampling>.
+<pre>&lt;sample entry 4CC>.&lt;profile>.&lt;still>.&lt;level>&lt;tier>.&lt;bitDepth>.&lt;monochrome>.&lt;chromaSubsampling>.
 &lt;colorPrimaries>.&lt;transferCharacteristics>.&lt;matrixCoefficients>.&lt;videoFullRangeFlag>
 </pre>
    <p>All fields following the sample entry 4CC are expressed as double digit decimals, unless indicated otherwise. Leading or trailing zeros cannot be omitted.</p>
    <p>The profile parameter value, represented by a single digit decimal, SHALL equal the value of seq_profile in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#" id="termref-for-⑧③">Sequence Header</a>.</p>
    <p>The still parameter value, represented by a single digit decimal, SHALL equal the value of still_picture in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#" id="termref-for-⑧④">Sequence Header</a>.</p>
    <p>The level parameter value SHALL equal the first level value indicated by <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#" id="termref-for-⑧⑤">seq_level_idx</a> in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#" id="termref-for-⑧⑥">Sequence Header</a>.</p>
-   <p>The bitDepth parameter value SHALL equal the value of BitDepth variable as defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> derived from the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#" id="termref-for-⑧⑦">Sequence Header</a>.</p>
-   <p>The monochrome parameter value, represented by a single digit decimal, SHALL equal the value of mono_chrome in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#" id="termref-for-⑧⑧">Sequence Header</a>.</p>
+   <p>The tier parameter value SHALL be equal to <code>M</code> when the first <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#" id="termref-for-⑧⑦">seq_tier</a> value in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#" id="termref-for-⑧⑧">Sequence Header</a> is equal to 0, and <code>H</code> when it is equal to 1.</p>
+   <p>The bitDepth parameter value SHALL equal the value of BitDepth variable as defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> derived from the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#" id="termref-for-⑧⑨">Sequence Header</a>.</p>
+   <p>The monochrome parameter value, represented by a single digit decimal, SHALL equal the value of mono_chrome in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#" id="termref-for-⑨⓪">Sequence Header</a>.</p>
    <p>The chromaSubsampling parameter value, represented by a three-digit decimal, SHALL have its first digit equal to subsampling_x and its second digit equal to subsampling_y and the third digit equal to chroma_sample_position, if the first two values are non-zero, or 0 otheriwise.</p>
-   <p>The colorPrimaries, transferCharacteristics, matrixCoefficients and videoFullRangeFlag parameter values SHALL equal the value of matching fields in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#" id="termref-for-⑧⑨">Sequence Header</a>, if color_description_present_flag is set to 1, otherwise they SHOULD not be set, defaulting to the values below. The videoFullRangeFlag is represented by a single digit.</p>
-   <p>For example, codecs="av01.0.0.04.10.0.112.09.16.09.0" represents AV1 profile 0, non still picture mode, level 4, 10-bit content, non-monochrome, with 4:2:0 chroma subsampling, ITU-R BT.2100 color primaries, ITU BT.2100 PQ transfer characteristics, ITU-R BT.2100 YCbCr color matrix, and studio swing representation.</p>
+   <p>The colorPrimaries, transferCharacteristics, matrixCoefficients and videoFullRangeFlag parameter values SHALL equal the value of matching fields in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#" id="termref-for-⑨①">Sequence Header</a>, if color_description_present_flag is set to 1, otherwise they SHOULD not be set, defaulting to the values below. The videoFullRangeFlag is represented by a single digit.</p>
+   <p>For example, codecs="av01.0.0.04M.10.0.112.09.16.09.0" represents AV1 profile 0, non still picture mode, level 4, Main tier, 10-bit content, non-monochrome, with 4:2:0 chroma subsampling, ITU-R BT.2100 color primaries, ITU BT.2100 PQ transfer characteristics, ITU-R BT.2100 YCbCr color matrix, and studio swing representation.</p>
    <p>The parameters sample entry 4CC, profile, level, and bitDepth are all mandatory fields. If any of these fields are empty, or not within their allowed range, the processing device SHOULD treat it as an error.</p>
    <p>All the other fields (including their leading '.') are optional, mutually inclusive (all or none) fields. If not specified then the values listed in the table below are assumed.</p>
    <table class="def">
@@ -1804,7 +1805,7 @@ Quantity:   Zero or more.
       <td>videoFullRangeFlag
       <td>0 (studio swing representation)
    </table>
-   <p>The string codecs="av01.0.0.01.08" in this case would represent AV1 profile 0, non still picture mode, level 1, 8-bit content with 4:2:0 chroma subsampling, ITU-R BT.709 color primaries, transfer characteristics and matrix coefficients, and studio swing representation.</p>
+   <p>The string codecs="av01.0.0.01M.08" in this case would represent AV1 profile 0, non still picture mode, level 1, Main tier, 8-bit content with 4:2:0 chroma subsampling, ITU-R BT.709 color primaries, transfer characteristics and matrix coefficients, and studio swing representation.</p>
    <p>If any character that is not '.' or digits is encountered, the string SHALL be interpreted ignoring all the characters starting from that character.</p>
   </main>
   <div data-fill-with="conformance">
@@ -1993,7 +1994,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2009,7 +2010,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2025,7 +2026,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2041,7 +2042,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2057,7 +2058,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2073,7 +2074,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2089,7 +2090,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2105,7 +2106,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2121,7 +2122,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2137,7 +2138,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2153,7 +2154,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2169,7 +2170,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2185,7 +2186,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2201,7 +2202,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2217,7 +2218,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2233,7 +2234,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2249,7 +2250,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2265,7 +2266,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2281,7 +2282,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2297,7 +2298,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2313,7 +2314,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2329,7 +2330,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2345,7 +2346,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2361,7 +2362,7 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2377,7 +2378,23 @@ Quantity:   Zero or more.
     <li><a href="#termref-for-">2.8.2. Description</a>
     <li><a href="#termref-for-">4. Common Encryption</a>
     <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
-    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-">
+   <a href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#">https://aomediacodec.github.io/av1-spec/av1-spec.pdf#</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#termref-for-">1. Bitstream features overview</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a> <a href="#termref-for-">(10)</a> <a href="#termref-for-">(11)</a> <a href="#termref-for-">(12)</a> <a href="#termref-for-">(13)</a> <a href="#termref-for-">(14)</a> <a href="#termref-for-">(15)</a> <a href="#termref-for-">(16)</a> <a href="#termref-for-">(17)</a> <a href="#termref-for-">(18)</a>
+    <li><a href="#termref-for-">2. Basic Encapsulation Scheme</a>
+    <li><a href="#termref-for-">2.3.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
+    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a> <a href="#termref-for-">(10)</a> <a href="#termref-for-">(11)</a> <a href="#termref-for-">(12)</a> <a href="#termref-for-">(13)</a> <a href="#termref-for-">(14)</a> <a href="#termref-for-">(15)</a> <a href="#termref-for-">(16)</a> <a href="#termref-for-">(17)</a>
+    <li><a href="#termref-for-">2.5. AV1 Sample Format</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a> <a href="#termref-for-">(10)</a> <a href="#termref-for-">(11)</a> <a href="#termref-for-">(12)</a> <a href="#termref-for-">(13)</a> <a href="#termref-for-">(14)</a> <a href="#termref-for-">(15)</a>
+    <li><a href="#termref-for-">2.6.2. Description</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">2.6.4. Semantics</a>
+    <li><a href="#termref-for-">2.8.2. Description</a>
+    <li><a href="#termref-for-">4. Common Encryption</a>
+    <li><a href="#termref-for-">4.1. Sample Encryption</a> <a href="#termref-for-">(2)</a>
+    <li><a href="#termref-for-">5. Codecs Parameter String</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2524,38 +2541,39 @@ Quantity:   Zero or more.
      <li><span class="dfn-paneled" id="term-for-①⑥" style="color:initial">random access point</span>
      <li><span class="dfn-paneled" id="term-for-①⑦" style="color:initial">s frame</span>
      <li><span class="dfn-paneled" id="term-for-①⑧" style="color:initial">seq_level_idx</span>
-     <li><span class="dfn-paneled" id="term-for-①⑨" style="color:initial">sequence header</span>
-     <li><span class="dfn-paneled" id="term-for-②⓪" style="color:initial">show_existing_frame</span>
-     <li><span class="dfn-paneled" id="term-for-②①" style="color:initial">show_frame</span>
-     <li><span class="dfn-paneled" id="term-for-②②" style="color:initial">temporal unit</span>
-     <li><span class="dfn-paneled" id="term-for-②③" style="color:initial">timing_info</span>
-     <li><span class="dfn-paneled" id="term-for-②④" style="color:initial">timing_info_present_flag</span>
+     <li><span class="dfn-paneled" id="term-for-①⑨" style="color:initial">seq_tier</span>
+     <li><span class="dfn-paneled" id="term-for-②⓪" style="color:initial">sequence header</span>
+     <li><span class="dfn-paneled" id="term-for-②①" style="color:initial">show_existing_frame</span>
+     <li><span class="dfn-paneled" id="term-for-②②" style="color:initial">show_frame</span>
+     <li><span class="dfn-paneled" id="term-for-②③" style="color:initial">temporal unit</span>
+     <li><span class="dfn-paneled" id="term-for-②④" style="color:initial">timing_info</span>
+     <li><span class="dfn-paneled" id="term-for-②⑤" style="color:initial">timing_info_present_flag</span>
     </ul>
    <li>
     <a data-link-type="biblio">[CENC]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-②⑤" style="color:initial">cbcs</span>
-     <li><span class="dfn-paneled" id="term-for-②⑥" style="color:initial">cenc</span>
+     <li><span class="dfn-paneled" id="term-for-②⑥" style="color:initial">cbcs</span>
+     <li><span class="dfn-paneled" id="term-for-②⑦" style="color:initial">cenc</span>
     </ul>
    <li>
     <a data-link-type="biblio">[CMAF]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-②⑦" style="color:initial">cmaf video track</span>
+     <li><span class="dfn-paneled" id="term-for-②⑧" style="color:initial">cmaf video track</span>
     </ul>
    <li>
     <a data-link-type="biblio">[ISOBMFF]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-②⑧" style="color:initial">bitr</span>
-     <li><span class="dfn-paneled" id="term-for-②⑨" style="color:initial">colr</span>
-     <li><span class="dfn-paneled" id="term-for-③⓪" style="color:initial">ctts</span>
-     <li><span class="dfn-paneled" id="term-for-③①" style="color:initial">nclx</span>
-     <li><span class="dfn-paneled" id="term-for-③②" style="color:initial">pasp</span>
-     <li><span class="dfn-paneled" id="term-for-③③" style="color:initial">visualsampleentry</span>
+     <li><span class="dfn-paneled" id="term-for-②⑨" style="color:initial">bitr</span>
+     <li><span class="dfn-paneled" id="term-for-③⓪" style="color:initial">colr</span>
+     <li><span class="dfn-paneled" id="term-for-③①" style="color:initial">ctts</span>
+     <li><span class="dfn-paneled" id="term-for-③②" style="color:initial">nclx</span>
+     <li><span class="dfn-paneled" id="term-for-③③" style="color:initial">pasp</span>
+     <li><span class="dfn-paneled" id="term-for-③④" style="color:initial">visualsampleentry</span>
     </ul>
    <li>
     <a data-link-type="biblio">[RFC6381]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-③④" style="color:initial">codecs</span>
+     <li><span class="dfn-paneled" id="term-for-③⑤" style="color:initial">codecs</span>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>


### PR DESCRIPTION
Closes #18 

Similarly, I think we should also replace the still boolean by a letter 'V' for video profiles and 'S' for Still picture profiles. That would make the codecs more readable. 