### PR TITLE
AV1 spec PDF moved. Update links.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -42,46 +42,46 @@ url: http://iso.org/#; spec: RFC6381; type: property;
 url: https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=1; spec: AV1; type: dfn;
 	text: AV1 bitstream
 
-url: http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=39; spec: AV1; type: dfn;
+url: http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39; spec: AV1; type: dfn;
 	text: OBU
 
-url: http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=40; spec: AV1; type: dfn;
+url: http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40; spec: AV1; type: dfn;
 	text: OBU Header
 
-url: http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=49; spec: AV1; type: dfn;
+url: http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49; spec: AV1; type: dfn;
 	text: Frame Header OBU
 
-url: http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41; spec: AV1; type: dfn;
+url: http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41; spec: AV1; type: dfn;
 	text: Sequence Header OBU
 
-url: http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=46; spec: AV1; type: dfn;
+url: http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46; spec: AV1; type: dfn;
 	text: Temporal Delimiter OBU
 
-url: http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=72; spec: AV1; type: dfn;
+url: http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=72; spec: AV1; type: dfn;
 	text: Tile Group OBU
 
-url: http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=71; spec: AV1; type: dfn;
+url: http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71; spec: AV1; type: dfn;
 	text: Frame OBU
 
-url: http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=121; spec: AV1; type: dfn;
+url: http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=121; spec: AV1; type: dfn;
 	text: Tile List OBU
 
-url: http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=47; spec: AV1; type: dfn;
+url: http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47; spec: AV1; type: dfn;
 	text: Metadata OBU
 
-url: http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=206; spec: AV1; type: dfn;
+url: http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206; spec: AV1; type: dfn;
 	text: Random Access Point
 	text: Delayed Random Access Point
 	text: Key Frame Dependent Recovery Point
 
-url: http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13; spec: AV1; type: dfn
+url: http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13; spec: AV1; type: dfn
 	text: Inter Frame
 	text: Intra-only Frame
 	text: Key Frame
 	text: S Frame
 	text: Temporal Unit
 
-url: http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=39; spec: AV1; type: dfn
+url: http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39; spec: AV1; type: dfn
 	text: Low Overhead Bitstream Format
 
 url: http://iso.org/#; spec: CMAF; type: dfn;
@@ -92,10 +92,10 @@ url: http://iso.org/#; spec: CENC; type: dfn;
 	text: cbcs
 	text: cenc
 
-url: http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=45; spec: AV1; type: dfn
+url: http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=45; spec: AV1; type: dfn
 	text: timing_info
 
-url: http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2; spec: AV1; type: dfn;
+url: http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2; spec: AV1; type: dfn;
 	text: max_frame_height_minus_1
 	text: max_frame_width_minus_1
 	text: obu_has_size_field

--- a/index.html
+++ b/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 0e8880531a1904b4bc0b037759fa3cb386293992" name="generator">
   <link href="https://AOMediaCodec.github.io/av1-isobmff" rel="canonical">
-  <meta content="956263e2631c13e5db1e7cb85221cc0fa4ff3c87" name="document-revision">
+  <meta content="9f19952d7a90e0aee69a88ee82971381267dbcad" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1512,13 +1512,13 @@ pre .property::before, pre .property::after {
   </nav>
   <main>
    <h2 class="heading settled" data-level="1" id="bitstream-overview"><span class="secno">1. </span><span class="content">Bitstream features overview</span><a class="self-link" href="#bitstream-overview"></a></h2>
-    An <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=1" id="ref-for-page=1">AV1 bitstream</a> is composed of a sequence of <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39">OBUs</a>, grouped into <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13">Temporal Units</a>. 
+    An <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=1" id="ref-for-page=1">AV1 bitstream</a> is composed of a sequence of <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39">OBUs</a>, grouped into <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13">Temporal Units</a>. 
    <p>OBUs are made of a 1 or 2 bytes header, identifying in particular the type of OBU, followed by an optional length field and by an optional payload whose presence and content depend on the OBU type. Depending on its type, an OBU can carry configuration information, metadata or coded video data.</p>
    <p>Temporal Units are processed by a decoder in the order given by the bitstream. Each Temporal Unit is associated with a presentation time. Some Temporal Units may contain multiple frames to be decoded but only one is presented (when scalability is not used).</p>
    <p class="note" role="note"><span>NOTE:</span> The AV1 specification defines scalability features, but this version of storage in ISOBMFF does not specify specific tools for scalability. A future version of the specification may do so.</p>
-   <p>Frames carried in Temporal Units may have coding dependencies on frames carried previously in the same Temporal Unit or in previous Temporal Units. Frames that can be decoded without dependencies to previous frames are of two categories: <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13①">Key Frames</a> and <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13②">Intra-only Frames</a>. Frames that cannot be decoded independently are of three categories: <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13③">Inter Frames</a>, <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13④">S Frames</a> and frames with a <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2">show_existing_frame</a> flag set to 1.</p>
-   <p>Key Frames with the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①">show_frame</a> flag set to 1 have the additional property that after decoding the Key Frame, all frames can be decoded. They are called <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206">Random Access Points</a> in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>.</p>
-   <p>Key Frames with the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②">show_frame</a> flag set to 0 are called <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206①">Delayed Random Access Points</a>. <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206②">Delayed Random Access Points</a> have the additional property that if a future <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206③">Key Frame Dependent Recovery Point</a> exists, all frames following that <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206④">Key Frame Dependent Recovery Point</a> can be decoded. A <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑤">Key Frame Dependent Recovery Point</a> is a frame with <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2③">show_existing_frame</a> set to 1 which refers to a previous <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑥">Delayed Random Access Points</a>.</p>
+   <p>Frames carried in Temporal Units may have coding dependencies on frames carried previously in the same Temporal Unit or in previous Temporal Units. Frames that can be decoded without dependencies to previous frames are of two categories: <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13①">Key Frames</a> and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13②">Intra-only Frames</a>. Frames that cannot be decoded independently are of three categories: <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13③">Inter Frames</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13④">S Frames</a> and frames with a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2">show_existing_frame</a> flag set to 1.</p>
+   <p>Key Frames with the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①">show_frame</a> flag set to 1 have the additional property that after decoding the Key Frame, all frames can be decoded. They are called <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206">Random Access Points</a> in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>.</p>
+   <p>Key Frames with the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②">show_frame</a> flag set to 0 are called <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206①">Delayed Random Access Points</a>. <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206②">Delayed Random Access Points</a> have the additional property that if a future <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206③">Key Frame Dependent Recovery Point</a> exists, all frames following that <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206④">Key Frame Dependent Recovery Point</a> can be decoded. A <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑤">Key Frame Dependent Recovery Point</a> is a frame with <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2③">show_existing_frame</a> set to 1 which refers to a previous <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑥">Delayed Random Access Points</a>.</p>
    <h2 class="heading settled" data-level="2" id="basic-encapsulation"><span class="secno">2. </span><span class="content">Basic Encapsulation Scheme</span><a class="self-link" href="#basic-encapsulation"></a></h2>
    <p>This section describes the basic data structures used to signal encapsulation of <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=1" id="ref-for-page=1①">AV1 bitstreams</a> in <a data-link-type="biblio" href="#biblio-isobmff">[ISOBMFF]</a> containers.</p>
    <h3 class="heading settled" data-level="2.1" id="general-requirement"><span class="secno">2.1. </span><span class="content">General requirement</span><a class="self-link" href="#general-requirement"></a></h3>
@@ -1540,8 +1540,8 @@ Quantity:          One or more.
 }
 </pre>
    <h4 class="heading settled" data-level="2.3.4" id="av1sampleentry-semantics"><span class="secno">2.3.4. </span><span class="content">Semantics</span><a class="self-link" href="#av1sampleentry-semantics"></a></h4>
-   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="width">width<a class="self-link" href="#width"></a></dfn> and <dfn data-dfn-type="dfn" data-noexport="" id="height">height<a class="self-link" href="#height"></a></dfn> fields of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-">VisualSampleEntry</a> SHALL equal the values of <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2④">max_frame_width_minus_1</a> + 1 and <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑤">max_frame_height_minus_1</a> + 1 of the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41">Sequence Header OBU</a> applying to the samples associated with this sample entry.</p>
-   <p>As specified in <a data-link-type="biblio" href="#biblio-isobmff">[ISOBMFF]</a>, the width and height in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①">VisualSampleEntry</a> are specified in square pixels. If the video pixels are not square, then a <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-②">pasp</a> box SHALL be included and the track header width and height SHOULD match the values of <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑥">max_frame_width_minus_1</a> + 1 and <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑦">max_frame_height_minus_1</a> + 1 after the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-③">pasp</a> ratio has been applied.</p>
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="width">width<a class="self-link" href="#width"></a></dfn> and <dfn data-dfn-type="dfn" data-noexport="" id="height">height<a class="self-link" href="#height"></a></dfn> fields of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-">VisualSampleEntry</a> SHALL equal the values of <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2④">max_frame_width_minus_1</a> + 1 and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑤">max_frame_height_minus_1</a> + 1 of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41">Sequence Header OBU</a> applying to the samples associated with this sample entry.</p>
+   <p>As specified in <a data-link-type="biblio" href="#biblio-isobmff">[ISOBMFF]</a>, the width and height in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①">VisualSampleEntry</a> are specified in square pixels. If the video pixels are not square, then a <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-②">pasp</a> box SHALL be included and the track header width and height SHOULD match the values of <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑥">max_frame_width_minus_1</a> + 1 and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑦">max_frame_height_minus_1</a> + 1 after the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-③">pasp</a> ratio has been applied.</p>
    <p>The <dfn data-dfn-type="dfn" data-noexport="" id="compressorname">compressorname<a class="self-link" href="#compressorname"></a></dfn> field of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④">VisualSampleEntry</a> is an informative name. It is formatted in a fixed 32-byte field, with the first byte set to the number of bytes to be displayed, followed by that number of bytes of displayable data, followed by padding to complete 32 bytes total (including the size byte). The value "\012AOM Coding" is RECOMMENDED; the first byte is a count of the remaining bytes, here represented by \012, which (being octal 12) is decimal 10, the number of bytes in the rest of the string.</p>
    <p class="note" role="note"><span>NOTE:</span> Parsers may ignore the value of the compressorname field. It is specified in this document simply for legacy and backwards compatibility reasons.</p>
    <p>The <dfn data-dfn-type="dfn" data-noexport="" id="config">config<a class="self-link" href="#config"></a></dfn> field SHALL contain an <a data-link-type="dfn" href="#av1codecconfigurationbox" id="ref-for-av1codecconfigurationbox①">AV1CodecConfigurationBox</a> that applies to the samples associated with this sample entry.</p>
@@ -1580,33 +1580,33 @@ aligned (8) class AV1CodecConfigurationRecord {
     <li data-md="">
      <p>From any sample marked with the <a data-link-type="dfn" href="#av1forwardkeyframesamplegroupentry" id="ref-for-av1forwardkeyframesamplegroupentry">AV1ForwardKeyFrameSampleGroupEntry</a>, an AV1 bitstream is formed by first outputting the OBUs contained in the <a data-link-type="dfn" href="#av1codecconfigurationbox" id="ref-for-av1codecconfigurationbox④">AV1CodecConfigurationBox</a> and then by outputing all OBUs in the sample itself, then by outputting all OBUs in the samples, in order, starting from the sample at the distance indicated by the sample group.</p>
    </ul>
-   <p class="note" role="note"><span>NOTE:</span> The configOBUs field is expected to contain only OBU_SEQUENCE_HEADER and OBU_METADATA when the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47">metadata OBU</a> is applicable to all the associated samples.</p>
-   <p>OBUs stored in the configOBUs field follow the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑧">open_bitstream_unit</a> <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39①">Low Overhead Bitstream Format</a> syntax as specified in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>. The flag <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑨">obu_has_size_field</a> SHALL be set to 1, indicating that the size of the OBU payload follows the header, and that it is coded using LEB128.</p>
+   <p class="note" role="note"><span>NOTE:</span> The configOBUs field is expected to contain only OBU_SEQUENCE_HEADER and OBU_METADATA when the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47">metadata OBU</a> is applicable to all the associated samples.</p>
+   <p>OBUs stored in the configOBUs field follow the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑧">open_bitstream_unit</a> <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39①">Low Overhead Bitstream Format</a> syntax as specified in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>. The flag <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑨">obu_has_size_field</a> SHALL be set to 1, indicating that the size of the OBU payload follows the header, and that it is coded using LEB128.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="initial_presentation_delay_present">initial_presentation_delay_present</dfn> field indicates the presence of the initial_presentation_delay_minus_one field.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</dfn> field indicates the number of samples (minus one) that need be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⓪">seq_level_idx</a> in the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①">Sequence Header OBU</a> (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</dfn> field indicates the number of samples (minus one) that need be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⓪">seq_level_idx</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①">Sequence Header OBU</a> (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:</p>
    <ul>
     <li data-md="">
      <p>construct a hypothetical bitstream consisting of the OBUs carried in the sample entry followed by the OBUs carried in all the samples,</p>
     <li data-md="">
-     <p>set the first <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①①">initial_display_delay_minus_1</a> field of each <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②">Sequence Header OBU</a> to the number of frames contained in the first <a data-link-type="dfn" href="#initial_presentation_delay_minus_one" id="ref-for-initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</a> + 1 samples,</p>
+     <p>set the first <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①①">initial_display_delay_minus_1</a> field of each <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②">Sequence Header OBU</a> to the number of frames contained in the first <a data-link-type="dfn" href="#initial_presentation_delay_minus_one" id="ref-for-initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</a> + 1 samples,</p>
     <li data-md="">
-     <p>set the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①②">frame_presentation_time</a> field of the frame header of each presentable frame such that it matches the presentation time difference between the sample carrying this frame and the previous sample (if it exists, 0 otherwise)</p>
+     <p>set the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①②">frame_presentation_time</a> field of the frame header of each presentable frame such that it matches the presentation time difference between the sample carrying this frame and the previous sample (if it exists, 0 otherwise)</p>
     <li data-md="">
      <p>apply the display model verification algorithm.</p>
    </ul>
    <p>When smooth presentation can be guaranteed after decoding the first sample, the value 0 SHALL be used. If an ISOBMFF writer cannot verify the above procedure, <a data-link-type="dfn" href="#initial_presentation_delay_present" id="ref-for-initial_presentation_delay_present">initial_presentation_delay_present</a> SHALL be set to 0.</p>
-   <p>The presentation times of AV1 samples are given by the ISOBMFF structures. The <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①③">timing_info_present_flag</a> in the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41③">Sequence Header OBU</a> (in the configOBUs field or in the associated samples) SHOULD be set to 0. If set to 1, the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=45" id="ref-for-page=45">timing_info</a> structure of the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41④">Sequence Header OBU</a>, the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①④">frame_presentation_time</a> and <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑤">buffer_removal_time</a> fields of the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49">Frame Header OBUs</a>, if present, SHALL be ignored for the purpose of timed processing of the ISOBMFF file.</p>
-   <p>If a <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑥">colr</a> box is present in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-⑦">VisualSampleEntry</a> with a colour_type set to <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑧">nclx</a>, the values of colour_primaries, transfer_characteristics, and matrix_coefficients SHALL match the values given in the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑤">Sequence Header OBU</a> (in the configOBUs field or in the associated samples) if the color_description_present_flag is set to 1. Similarly, the full_range_flag in the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑨">colr</a> box shall match the color_range flag in the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑥">Sequence Header OBU</a>.</p>
+   <p>The presentation times of AV1 samples are given by the ISOBMFF structures. The <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①③">timing_info_present_flag</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41③">Sequence Header OBU</a> (in the configOBUs field or in the associated samples) SHOULD be set to 0. If set to 1, the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=45" id="ref-for-page=45">timing_info</a> structure of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41④">Sequence Header OBU</a>, the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①④">frame_presentation_time</a> and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑤">buffer_removal_time</a> fields of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49">Frame Header OBUs</a>, if present, SHALL be ignored for the purpose of timed processing of the ISOBMFF file.</p>
+   <p>If a <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑥">colr</a> box is present in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-⑦">VisualSampleEntry</a> with a colour_type set to <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑧">nclx</a>, the values of colour_primaries, transfer_characteristics, and matrix_coefficients SHALL match the values given in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑤">Sequence Header OBU</a> (in the configOBUs field or in the associated samples) if the color_description_present_flag is set to 1. Similarly, the full_range_flag in the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑨">colr</a> box shall match the color_range flag in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑥">Sequence Header OBU</a>.</p>
    <p>Additional boxes may be provided at the end of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⓪">VisualSampleEntry</a> as permitted by ISOBMFF, that may represent redundant or similar information to the one provided in some OBUs contained in the <a data-link-type="dfn" href="#av1codecconfigurationbox" id="ref-for-av1codecconfigurationbox⑤">AV1CodecConfigurationBox</a>. If the box definition does not indicate that its information overrides the OBU information, in case of conflict, the OBU information should be considered authoritative.</p>
    <h3 class="heading settled" data-level="2.5" id="sampleformat"><span class="secno">2.5. </span><span class="content">AV1 Sample Format</span><a class="self-link" href="#sampleformat"></a></h3>
    <p>For tracks using the <a data-link-type="dfn" href="#av1sampleentry" id="ref-for-av1sampleentry②">AV1SampleEntry</a>, an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1-sample">AV1 Sample</dfn> has the following constraints:</p>
    <ul>
     <li data-md="">
-     <p>the sample data SHALL be a sequence of <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39②">OBUs</a> forming a <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑤">Temporal Unit</a>,</p>
+     <p>the sample data SHALL be a sequence of <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39②">OBUs</a> forming a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑤">Temporal Unit</a>,</p>
     <li data-md="">
-     <p>each OBU SHALL follow the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑥">open_bitstream_unit</a> <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39③">Low Overhead Bitstream Format</a> syntax as specified in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>. Each OBU SHALL have the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑦">obu_has_size_field</a> set to 1 except for the last OBU in the sample, for which <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑧">obu_has_size_field</a> MAY be set to 0, in which case it is assumed to fill the remaining of the sample,</p>
+     <p>each OBU SHALL follow the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑥">open_bitstream_unit</a> <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39③">Low Overhead Bitstream Format</a> syntax as specified in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>. Each OBU SHALL have the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑦">obu_has_size_field</a> set to 1 except for the last OBU in the sample, for which <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑧">obu_has_size_field</a> MAY be set to 0, in which case it is assumed to fill the remaining of the sample,</p>
    </ul>
-   <p class="note" role="note"><span>NOTE:</span> When extracting OBUs from an ISOBMFF file, and depending on the capabilities of the decoder processing these OBUs, ISOBMFF parsers MAY need to either set the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑨">obu_has_size_field</a> to 1 for some OBUs if not already set and add the length field, or use the length-delimited bitstream format as defined in Annex B of <a data-link-type="dfn" href="#av1s" id="ref-for-av1s">AV1</a>.</p>
+   <p class="note" role="note"><span>NOTE:</span> When extracting OBUs from an ISOBMFF file, and depending on the capabilities of the decoder processing these OBUs, ISOBMFF parsers MAY need to either set the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑨">obu_has_size_field</a> to 1 for some OBUs if not already set and add the length field, or use the length-delimited bitstream format as defined in Annex B of <a data-link-type="dfn" href="#av1s" id="ref-for-av1s">AV1</a>.</p>
    <ul>
     <li data-md="">
      <p>OBU trailing bits SHOULD be limited to byte alignment and SHOULD not be used for padding,</p>
@@ -1616,19 +1616,19 @@ aligned (8) class AV1CodecConfigurationRecord {
    <p>If an AV1 Sample is signaled as a sync sample (in the SyncSampleBox or by setting sample_is_non_sync_sample to 0), it SHALL be a Random Access Point as defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>, i.e. satisfy the following constraints:</p>
    <ul>
     <li data-md="">
-     <p>Its first frame is a <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑥">Key Frame</a> that has <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⓪">show_frame</a> flag set to 1,</p>
+     <p>Its first frame is a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑥">Key Frame</a> that has <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⓪">show_frame</a> flag set to 1,</p>
     <li data-md="">
-     <p>It contains a <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑦">Sequence Header OBU</a> before the first <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49①">Frame Header OBU</a>.</p>
+     <p>It contains a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑦">Sequence Header OBU</a> before the first <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49①">Frame Header OBU</a>.</p>
    </ul>
    <p class="note" role="note"><span>NOTE:</span> Within this definition, a sync sample may contain additional frames that are not Key Frames. The fact that none of them is the first frame in the temporal unit ensures that they are decodable.</p>
-   <p class="note" role="note"><span>NOTE:</span> Other types of OBUs such as <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47①">metadata OBUs</a> could be present before the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑧">Sequence Header OBU</a>.</p>
-   <p><a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑦">Intra-only frames</a> SHOULD be signaled using the sample_depends_on flag set to 2.</p>
-   <p><a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑦">Delayed Random Access Points</a> SHOULD be signaled using sample groups and the <a data-link-type="dfn" href="#av1forwardkeyframesamplegroupentry" id="ref-for-av1forwardkeyframesamplegroupentry①">AV1ForwardKeyFrameSampleGroupEntry</a>.</p>
-   <p><a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑧">S Frames</a> SHOULD be signaled using sample groups and the <a data-link-type="dfn" href="#av1sframesamplegroupentry" id="ref-for-av1sframesamplegroupentry">AV1SFrameSampleGroupEntry</a>.</p>
-   <p>Additionally, if a file contains multiple tracks which are alternative representations of the same content, in particular using <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑨">S Frames</a>, those tracks SHOULD be marked as belonging to the same alternate group and should use a track selection box with an appropriate attribute (e.g. <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-①①">bitr</a>).</p>
+   <p class="note" role="note"><span>NOTE:</span> Other types of OBUs such as <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47①">metadata OBUs</a> could be present before the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑧">Sequence Header OBU</a>.</p>
+   <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑦">Intra-only frames</a> SHOULD be signaled using the sample_depends_on flag set to 2.</p>
+   <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑦">Delayed Random Access Points</a> SHOULD be signaled using sample groups and the <a data-link-type="dfn" href="#av1forwardkeyframesamplegroupentry" id="ref-for-av1forwardkeyframesamplegroupentry①">AV1ForwardKeyFrameSampleGroupEntry</a>.</p>
+   <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑧">S Frames</a> SHOULD be signaled using sample groups and the <a data-link-type="dfn" href="#av1sframesamplegroupentry" id="ref-for-av1sframesamplegroupentry">AV1SFrameSampleGroupEntry</a>.</p>
+   <p>Additionally, if a file contains multiple tracks which are alternative representations of the same content, in particular using <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑨">S Frames</a>, those tracks SHOULD be marked as belonging to the same alternate group and should use a track selection box with an appropriate attribute (e.g. <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-①①">bitr</a>).</p>
    <p>Unlike many video standards, AV1 does not distinguish the display order from the decoding order, but achieves similar effects by grouping multiple frames within a sample. Therefore, composition offsets are not used. In tracks using the <a data-link-type="dfn" href="#av1sampleentry" id="ref-for-av1sampleentry③">AV1SampleEntry</a>, the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-①②">ctts</a> box and composition offsets in movie fragments SHALL NOT be used. Similarly, the is_leading flag, if used, SHALL be set to 0 or 2.</p>
    <p>When a temporal unit contains more than one frame, the sample corresponding to that temporal unit MAY be marked using the <a data-link-type="dfn" href="#av1multiframesamplegroupentry" id="ref-for-av1multiframesamplegroupentry">AV1MultiFrameSampleGroupEntry</a>.</p>
-   <p><a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47②">Metadata OBUs</a> may be carried in sample data. In this case, the <a data-link-type="dfn" href="#av1metadatasamplegroupentry" id="ref-for-av1metadatasamplegroupentry">AV1MetadataSampleGroupEntry</a> SHOULD be used. If the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47③">metadata OBUs</a> are static for the entire set of samples associated with a given sample description entry, they SHOULD also be in the OBU array in the sample description entry.</p>
+   <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47②">Metadata OBUs</a> may be carried in sample data. In this case, the <a data-link-type="dfn" href="#av1metadatasamplegroupentry" id="ref-for-av1metadatasamplegroupentry">AV1MetadataSampleGroupEntry</a> SHOULD be used. If the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47③">metadata OBUs</a> are static for the entire set of samples associated with a given sample description entry, they SHOULD also be in the OBU array in the sample description entry.</p>
    <p>Unless explicitely stated, the grouping_type_parameter is not defined for the SampleToGroupBox with grouping types defined in this specification.</p>
    <h3 class="heading settled" data-level="2.6" id="forwardkeyframesamplegroupentry"><span class="secno">2.6. </span><span class="content">AV1 Forward Key Frame sample group entry</span><a class="self-link" href="#forwardkeyframesamplegroupentry"></a></h3>
    <h4 class="heading settled" data-level="2.6.1" id="forwardkeyframesamplegroupentry-definition"><span class="secno">2.6.1. </span><span class="content">Definition</span><a class="self-link" href="#forwardkeyframesamplegroupentry-definition"></a></h4>
@@ -1638,14 +1638,14 @@ Mandatory:  No
 Quantity:   Zero or more.
 </pre>
    <h4 class="heading settled" data-level="2.6.2" id="forwardkeyframesamplegroupentry-description"><span class="secno">2.6.2. </span><span class="content">Description</span><a class="self-link" href="#forwardkeyframesamplegroupentry-description"></a></h4>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1forwardkeyframesamplegroupentry">AV1ForwardKeyFrameSampleGroupEntry</dfn> documents samples that contain a <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑧">Delayed Random Access Point</a> that are followed at a given distance in the bitstream by a <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑨">Key Frame Dependent Recovery Point</a>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1forwardkeyframesamplegroupentry">AV1ForwardKeyFrameSampleGroupEntry</dfn> documents samples that contain a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑧">Delayed Random Access Point</a> that are followed at a given distance in the bitstream by a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑨">Key Frame Dependent Recovery Point</a>.</p>
    <h4 class="heading settled" data-level="2.6.3" id="forwardkeyframesamplegroupentry-syntax"><span class="secno">2.6.3. </span><span class="content">Syntax</span><a class="self-link" href="#forwardkeyframesamplegroupentry-syntax"></a></h4>
 <pre>class AV1ForwardKeyFrameSampleGroupEntry extends VisualSampleGroupEntry('av1f') {
   unsigned int(8) fwd_distance;
 }
 </pre>
    <h4 class="heading settled" data-level="2.6.4" id="forwardkeyframesamplegroupentry-semantics"><span class="secno">2.6.4. </span><span class="content">Semantics</span><a class="self-link" href="#forwardkeyframesamplegroupentry-semantics"></a></h4>
-   <p>The <dfn data-dfn-type="dfn" data-export="" id="fwd_distance">fwd_distance<a class="self-link" href="#fwd_distance"></a></dfn> field indicates the number of samples between this sample and the next sample containing the associated <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206①⓪">Key Frame Dependent Recovery Point</a>. 0 means the next sample.</p>
+   <p>The <dfn data-dfn-type="dfn" data-export="" id="fwd_distance">fwd_distance<a class="self-link" href="#fwd_distance"></a></dfn> field indicates the number of samples between this sample and the next sample containing the associated <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206①⓪">Key Frame Dependent Recovery Point</a>. 0 means the next sample.</p>
    <h3 class="heading settled" data-level="2.7" id="multiframesamplegroupentry"><span class="secno">2.7. </span><span class="content">AV1 Multi-Frame sample group entry</span><a class="self-link" href="#multiframesamplegroupentry"></a></h3>
    <h4 class="heading settled" data-level="2.7.1" id="multiframesamplegroupentry-definition"><span class="secno">2.7.1. </span><span class="content">Definition</span><a class="self-link" href="#multiframesamplegroupentry-definition"></a></h4>
 <pre class="def">Group Type: <dfn data-dfn-for="AV1MultiFrameSampleGroupEntry" data-dfn-type="value" data-export="" id="valdef-av1multiframesamplegroupentry-av1m">av1m<a class="self-link" href="#valdef-av1multiframesamplegroupentry-av1m"></a></dfn>
@@ -1667,7 +1667,7 @@ Mandatory:  No
 Quantity:   Zero or more.
 </pre>
    <h4 class="heading settled" data-level="2.8.2" id="sframeamplegroupentry-description"><span class="secno">2.8.2. </span><span class="content">Description</span><a class="self-link" href="#sframeamplegroupentry-description"></a></h4>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1sframesamplegroupentry">AV1SFrameSampleGroupEntry</dfn> documents samples that start with an <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13①⓪">S Frame</a>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1sframesamplegroupentry">AV1SFrameSampleGroupEntry</dfn> documents samples that start with an <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13①⓪">S Frame</a>.</p>
    <h4 class="heading settled" data-level="2.8.3" id="sframeamplegroupentry-syntax"><span class="secno">2.8.3. </span><span class="content">Syntax</span><a class="self-link" href="#sframeamplegroupentry-syntax"></a></h4>
 <pre>class AV1SFrameSampleGroupEntry extends VisualSampleGroupEntry('av1s') {
 }
@@ -1680,7 +1680,7 @@ Mandatory:  No
 Quantity:   Zero or more.
 </pre>
    <h4 class="heading settled" data-level="2.9.2" id="metadatasamplegroupentry-description"><span class="secno">2.9.2. </span><span class="content">Description</span><a class="self-link" href="#metadatasamplegroupentry-description"></a></h4>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1metadatasamplegroupentry">AV1MetadataSampleGroupEntry</dfn> documents samples that contain <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47④">metadata OBUs</a> of the given type.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1metadatasamplegroupentry">AV1MetadataSampleGroupEntry</dfn> documents samples that contain <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47④">metadata OBUs</a> of the given type.</p>
    <h4 class="heading settled" data-level="2.9.3" id="metadatasamplegroupentry-syntax"><span class="secno">2.9.3. </span><span class="content">Syntax</span><a class="self-link" href="#metadatasamplegroupentry-syntax"></a></h4>
 <pre>class AV1MetadataSampleGroupEntry extends VisualSampleGroupEntry('av1M') {
   unsigned int (16) metadata_type;
@@ -1707,7 +1707,7 @@ Quantity:   Zero or more.
     <li data-md="">
      <p>the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-①④">colr</a> and <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-①⑤">pasp</a> boxes SHALL be present</p>
     <li data-md="">
-     <p>for HDR profiles, <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47⑤">metadata OBUs</a> of type METADATA_TYPE_HDR_CLL and METADATA_TYPE_HDR_MDCV should be present.</p>
+     <p>for HDR profiles, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47⑤">metadata OBUs</a> of type METADATA_TYPE_HDR_CLL and METADATA_TYPE_HDR_MDCV should be present.</p>
    </ul>
    <p>When encrypted, <a data-link-type="dfn" href="#cmaf-av1-track" id="ref-for-cmaf-av1-track">CMAF AV1 Tracks</a> SHALL use the signaling defined in <a data-link-type="biblio" href="#biblio-cmaf">[CMAF]</a>, which in turns relies on <a data-link-type="biblio" href="#biblio-cenc">[CENC]</a>, with the provisions specified in <a href="#CommonEncryption">§4 Common Encryption</a>.</p>
    <p>The following brands are defined for <a data-link-type="dfn" href="#cmaf-av1-track" id="ref-for-cmaf-av1-track①">CMAF AV1 Tracks</a>:</p>
@@ -1759,12 +1759,12 @@ Quantity:   Zero or more.
    <h2 class="heading settled" data-level="4" id="CommonEncryption"><span class="secno">4. </span><span class="content">Common Encryption</span><a class="self-link" href="#CommonEncryption"></a></h2>
    <p><a data-link-type="dfn" href="#cmaf-av1-track" id="ref-for-cmaf-av1-track②">CMAF AV1 Tracks</a> and non-segmented AV1 files MAY be encrypted. If encrypted, they SHALL conform to <a data-link-type="biblio" href="#biblio-cenc">[CENC]</a>. In particular, both <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑥">cenc</a></code> and <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑦">cbcs</a></code> scheme types are permitted.</p>
    <h3 class="heading settled" data-level="4.1" id="sample-encryption"><span class="secno">4.1. </span><span class="content">Sample Encryption</span><a class="self-link" href="#sample-encryption"></a></h3>
-   <p>When encrypting <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39④">OBUs</a>, all <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40">OBU Headers</a> and associated <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②①">obu_size</a> fields SHALL be unencrypted. Additionally, <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46">Temporal Delimiter OBUs</a>, <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑨">Sequence Header OBUs</a>, <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47⑥">Metadata OBUs</a> (except for those requiring protection), <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49②">Frame Header OBUs</a> SHALL be unencrypted.</p>
-   <p>Within encrypted samples, all <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40①">OBU Headers</a> and associated <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②②">obu_size</a> fields SHALL be unencrypted. Additionally, <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46①">Temporal Delimiter OBUs</a>, <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⓪">Sequence Header OBUs</a>, <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47⑦">Metadata OBUs</a> (except for those requiring protection), <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49③">Frame Header OBUs</a> (including with a <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71">Frame OBU</a>) SHALL be unencrypted. <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=72" id="ref-for-page=72">Tile Group OBUs</a>, <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71①">Frame OBUs</a> (except the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49④">Frame Header OBU</a> part) and <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=121" id="ref-for-page=121">Tile List OBUs</a> MAY be encrypted. This is illustrated in Figure #1 and Figure #2, where for simplicity the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②③">obu_size</a> field is assumed to be part of the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40②">OBU Header</a>.</p>
+   <p>When encrypting <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39④">OBUs</a>, all <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40">OBU Headers</a> and associated <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②①">obu_size</a> fields SHALL be unencrypted. Additionally, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46">Temporal Delimiter OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑨">Sequence Header OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47⑥">Metadata OBUs</a> (except for those requiring protection), <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49②">Frame Header OBUs</a> SHALL be unencrypted.</p>
+   <p>Within encrypted samples, all <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40①">OBU Headers</a> and associated <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②②">obu_size</a> fields SHALL be unencrypted. Additionally, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46①">Temporal Delimiter OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⓪">Sequence Header OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47⑦">Metadata OBUs</a> (except for those requiring protection), <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49③">Frame Header OBUs</a> (including with a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71">Frame OBU</a>) SHALL be unencrypted. <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=72" id="ref-for-page=72">Tile Group OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71①">Frame OBUs</a> (except the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49④">Frame Header OBU</a> part) and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=121" id="ref-for-page=121">Tile List OBUs</a> MAY be encrypted. This is illustrated in Figure #1 and Figure #2, where for simplicity the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②③">obu_size</a> field is assumed to be part of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40②">OBU Header</a>.</p>
    <p>As permitted by <a data-link-type="biblio" href="#biblio-cenc">[CENC]</a>, multiple unencrypted OBUs MAY be described by a single subsample. Also, mutiple subsamples MAY be used to describe the data of a single OBU.</p>
    <p>When an OBU is encrypted, <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑧">BytesOfProtectedData</a> SHALL span all complete 16-byte blocks in the OBU data that is permitted to be encrypted.</p>
    <p>For AES-CTR based scheme types, such as <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑨">cenc</a></code>, the encrypted bytes of each OBU within the sample SHALL be block-aligned so that the counter state can be computed for each OBU within the sample. Block alignment is achieved by adjusting the size of the unencrypted bytes that precede the encrypted bytes for that OBU. In other words, partial blocks are not permitted.</p>
-   <p>For AES-CBC based scheme types, such as <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-②⓪">cbcs</a></code>, <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-②①">BytesOfProtectedData</a> SHALL start on the first complete byte of OBU data that is permitted to be encrypted (i.e. after the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40③">OBU Header</a>, <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②④">obu_size</a>, possible <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49⑤">Frame Header OBU</a> and <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⑤">byte_alignment</a>), and end on the end of the last complete 16-byte block of slice data in the video NAL unit. Partial blocks at the end of OBUs, if any, SHALL be left unencrypted as specified in <a data-link-type="biblio" href="#biblio-cenc">[CENC]</a>.</p>
+   <p>For AES-CBC based scheme types, such as <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-②⓪">cbcs</a></code>, <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-②①">BytesOfProtectedData</a> SHALL start on the first complete byte of OBU data that is permitted to be encrypted (i.e. after the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40③">OBU Header</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②④">obu_size</a>, possible <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49⑤">Frame Header OBU</a> and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⑤">byte_alignment</a>), and end on the end of the last complete 16-byte block of slice data in the video NAL unit. Partial blocks at the end of OBUs, if any, SHALL be left unencrypted as specified in <a data-link-type="biblio" href="#biblio-cenc">[CENC]</a>.</p>
    <figure>
      <img alt="Simplified subsample-based AV1 encryption" src="images/subsample-encryption-no-type.svg"> 
     <figcaption>Subsample-based AV1 encryption with clear OBU headers with OBU types omitted.</figcaption>
@@ -1779,13 +1779,13 @@ Quantity:   Zero or more.
 &lt;colorPrimaries>.&lt;transferCharacteristics>.&lt;matrixCoefficients>.&lt;videoFullRangeFlag>
 </pre>
    <p>All fields following the sample entry 4CC are expressed as double digit decimals, unless indicated otherwise. Leading or trailing zeros cannot be omitted.</p>
-   <p>The profile parameter value, represented by a single digit decimal, SHALL equal the value of seq_profile in the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①①">Sequence Header OBU</a>.</p>
-   <p>The level parameter value SHALL equal the first level value indicated by <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⑥">seq_level_idx</a> in the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①②">Sequence Header OBU</a>.</p>
-   <p>The tier parameter value SHALL be equal to <code>M</code> when the first <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⑦">seq_tier</a> value in the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①③">Sequence Header OBU</a> is equal to 0, and <code>H</code> when it is equal to 1.</p>
-   <p>The bitDepth parameter value SHALL equal the value of BitDepth variable as defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> derived from the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①④">Sequence Header OBU</a>.</p>
-   <p>The monochrome parameter value, represented by a single digit decimal, SHALL equal the value of mono_chrome in the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑤">Sequence Header OBU</a>.</p>
+   <p>The profile parameter value, represented by a single digit decimal, SHALL equal the value of seq_profile in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①①">Sequence Header OBU</a>.</p>
+   <p>The level parameter value SHALL equal the first level value indicated by <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⑥">seq_level_idx</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①②">Sequence Header OBU</a>.</p>
+   <p>The tier parameter value SHALL be equal to <code>M</code> when the first <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⑦">seq_tier</a> value in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①③">Sequence Header OBU</a> is equal to 0, and <code>H</code> when it is equal to 1.</p>
+   <p>The bitDepth parameter value SHALL equal the value of BitDepth variable as defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> derived from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①④">Sequence Header OBU</a>.</p>
+   <p>The monochrome parameter value, represented by a single digit decimal, SHALL equal the value of mono_chrome in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑤">Sequence Header OBU</a>.</p>
    <p>The chromaSubsampling parameter value, represented by a three-digit decimal, SHALL have its first digit equal to subsampling_x and its second digit equal to subsampling_y. If both subsampling_x and subsampling_y are set to 1, then the third digit SHALL be equal to chroma_sample_position, otherwise it SHALL be set to 0.</p>
-   <p>The colorPrimaries, transferCharacteristics, matrixCoefficients and videoFullRangeFlag parameter values SHALL equal the value of matching fields in the <a data-link-type="dfn" href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑥">Sequence Header OBU</a>, if color_description_present_flag is set to 1, otherwise they SHOULD not be set, defaulting to the values below. The videoFullRangeFlag is represented by a single digit.</p>
+   <p>The colorPrimaries, transferCharacteristics, matrixCoefficients and videoFullRangeFlag parameter values SHALL equal the value of matching fields in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑥">Sequence Header OBU</a>, if color_description_present_flag is set to 1, otherwise they SHOULD not be set, defaulting to the values below. The videoFullRangeFlag is represented by a single digit.</p>
    <p>For example, codecs="av01.0.04M.10.0.112.09.16.09.0" represents AV1 profile 0, level 4, Main tier, 10-bit content, non-monochrome, with 4:2:0 chroma subsampling, ITU-R BT.2100 color primaries, ITU BT.2100 PQ transfer characteristics, ITU-R BT.2100 YCbCr color matrix, and studio swing representation.</p>
    <p>The parameters sample entry 4CC, profile, level, tier, and bitDepth are all mandatory fields. If any of these fields are empty, or not within their allowed range, the processing device SHOULD treat it as an error.</p>
    <p>All the other fields (including their leading '.') are optional, mutually inclusive (all or none) fields. If not specified then the values listed in the table below are assumed.</p>
@@ -1999,7 +1999,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
@@ -2010,7 +2010,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
@@ -2021,7 +2021,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=206">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=206">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=206</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=206">1. Bitstream features overview</a> <a href="#ref-for-page=206①">(2)</a> <a href="#ref-for-page=206②">(3)</a> <a href="#ref-for-page=206③">(4)</a> <a href="#ref-for-page=206④">(5)</a> <a href="#ref-for-page=206⑤">(6)</a> <a href="#ref-for-page=206⑥">(7)</a>
     <li><a href="#ref-for-page=206⑦">2.5. AV1 Sample Format</a>
@@ -2030,7 +2030,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=49">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=49">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=49</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=49">2.4.4. Semantics</a>
     <li><a href="#ref-for-page=49①">2.5. AV1 Sample Format</a>
@@ -2038,13 +2038,13 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=71">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=71">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=71</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=71">4.1. Sample Encryption</a> <a href="#ref-for-page=71①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
@@ -2055,7 +2055,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
@@ -2066,7 +2066,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=13">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=13">1. Bitstream features overview</a> <a href="#ref-for-page=13①">(2)</a> <a href="#ref-for-page=13②">(3)</a> <a href="#ref-for-page=13③">(4)</a> <a href="#ref-for-page=13④">(5)</a>
     <li><a href="#ref-for-page=13⑤">2.5. AV1 Sample Format</a> <a href="#ref-for-page=13⑥">(2)</a> <a href="#ref-for-page=13⑦">(3)</a> <a href="#ref-for-page=13⑧">(4)</a> <a href="#ref-for-page=13⑨">(5)</a>
@@ -2074,7 +2074,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=13">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=13">1. Bitstream features overview</a> <a href="#ref-for-page=13①">(2)</a> <a href="#ref-for-page=13②">(3)</a> <a href="#ref-for-page=13③">(4)</a> <a href="#ref-for-page=13④">(5)</a>
     <li><a href="#ref-for-page=13⑤">2.5. AV1 Sample Format</a> <a href="#ref-for-page=13⑥">(2)</a> <a href="#ref-for-page=13⑦">(3)</a> <a href="#ref-for-page=13⑧">(4)</a> <a href="#ref-for-page=13⑨">(5)</a>
@@ -2082,7 +2082,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=13">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=13">1. Bitstream features overview</a> <a href="#ref-for-page=13①">(2)</a> <a href="#ref-for-page=13②">(3)</a> <a href="#ref-for-page=13③">(4)</a> <a href="#ref-for-page=13④">(5)</a>
     <li><a href="#ref-for-page=13⑤">2.5. AV1 Sample Format</a> <a href="#ref-for-page=13⑥">(2)</a> <a href="#ref-for-page=13⑦">(3)</a> <a href="#ref-for-page=13⑧">(4)</a> <a href="#ref-for-page=13⑨">(5)</a>
@@ -2090,7 +2090,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=206">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=206">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=206</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=206">1. Bitstream features overview</a> <a href="#ref-for-page=206①">(2)</a> <a href="#ref-for-page=206②">(3)</a> <a href="#ref-for-page=206③">(4)</a> <a href="#ref-for-page=206④">(5)</a> <a href="#ref-for-page=206⑤">(6)</a> <a href="#ref-for-page=206⑥">(7)</a>
     <li><a href="#ref-for-page=206⑦">2.5. AV1 Sample Format</a>
@@ -2099,7 +2099,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=39">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=39">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=39</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=39">1. Bitstream features overview</a>
     <li><a href="#ref-for-page=39①">2.4.4. Semantics</a>
@@ -2108,7 +2108,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
@@ -2119,7 +2119,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
@@ -2130,7 +2130,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=47">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=47">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=47</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=47">2.4.4. Semantics</a>
     <li><a href="#ref-for-page=47①">2.5. AV1 Sample Format</a> <a href="#ref-for-page=47②">(2)</a> <a href="#ref-for-page=47③">(3)</a>
@@ -2140,7 +2140,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=39">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=39">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=39</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=39">1. Bitstream features overview</a>
     <li><a href="#ref-for-page=39①">2.4.4. Semantics</a>
@@ -2149,13 +2149,13 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=40">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=40">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=40</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=40">4.1. Sample Encryption</a> <a href="#ref-for-page=40①">(2)</a> <a href="#ref-for-page=40②">(3)</a> <a href="#ref-for-page=40③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
@@ -2166,7 +2166,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
@@ -2177,7 +2177,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
@@ -2188,7 +2188,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=206">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=206">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=206</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=206">1. Bitstream features overview</a> <a href="#ref-for-page=206①">(2)</a> <a href="#ref-for-page=206②">(3)</a> <a href="#ref-for-page=206③">(4)</a> <a href="#ref-for-page=206④">(5)</a> <a href="#ref-for-page=206⑤">(6)</a> <a href="#ref-for-page=206⑥">(7)</a>
     <li><a href="#ref-for-page=206⑦">2.5. AV1 Sample Format</a>
@@ -2197,7 +2197,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=13">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=13">1. Bitstream features overview</a> <a href="#ref-for-page=13①">(2)</a> <a href="#ref-for-page=13②">(3)</a> <a href="#ref-for-page=13③">(4)</a> <a href="#ref-for-page=13④">(5)</a>
     <li><a href="#ref-for-page=13⑤">2.5. AV1 Sample Format</a> <a href="#ref-for-page=13⑥">(2)</a> <a href="#ref-for-page=13⑦">(3)</a> <a href="#ref-for-page=13⑧">(4)</a> <a href="#ref-for-page=13⑨">(5)</a>
@@ -2205,7 +2205,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
@@ -2216,7 +2216,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
@@ -2227,7 +2227,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=41">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=41</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=41">2.3.4. Semantics</a>
     <li><a href="#ref-for-page=41①">2.4.4. Semantics</a> <a href="#ref-for-page=41②">(2)</a> <a href="#ref-for-page=41③">(3)</a> <a href="#ref-for-page=41④">(4)</a> <a href="#ref-for-page=41⑤">(5)</a> <a href="#ref-for-page=41⑥">(6)</a>
@@ -2237,7 +2237,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
@@ -2248,7 +2248,7 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
@@ -2259,13 +2259,13 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=46">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=46">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=46</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=46">4.1. Sample Encryption</a> <a href="#ref-for-page=46①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=13">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=13</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=13">1. Bitstream features overview</a> <a href="#ref-for-page=13①">(2)</a> <a href="#ref-for-page=13②">(3)</a> <a href="#ref-for-page=13③">(4)</a> <a href="#ref-for-page=13④">(5)</a>
     <li><a href="#ref-for-page=13⑤">2.5. AV1 Sample Format</a> <a href="#ref-for-page=13⑥">(2)</a> <a href="#ref-for-page=13⑦">(3)</a> <a href="#ref-for-page=13⑧">(4)</a> <a href="#ref-for-page=13⑨">(5)</a>
@@ -2273,25 +2273,25 @@ Quantity:   Zero or more.
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=72">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=72">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=72</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=72">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=72</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=72">4.1. Sample Encryption</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=121">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=121">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=121</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=121">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=121</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=121">4.1. Sample Encryption</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=45">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=45">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=45</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=45">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=45</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=45">2.4.4. Semantics</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
-   <a href="http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2">http://av1-spec.argondesign.com/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>


### PR DESCRIPTION
@cconcolato: FYI again; fixed the links. AV1 spec is now hosted on github.io. 