### PR TITLE
Update vocabulary to match AV1 1.0.0 specification

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -78,7 +78,7 @@ url: http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13; spec: AV1; typ
 	text: Inter Frame
 	text: Intra-only Frame
 	text: Key Frame
-	text: S Frame
+	text: Switch Frame
 	text: Temporal Unit
 
 url: http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39; spec: AV1; type: dfn
@@ -122,7 +122,7 @@ Temporal Units are processed by a decoder in the order given by the bitstream. E
 
 NOTE: The AV1 specification defines scalability features, but this version of storage in ISOBMFF does not specify specific tools for scalability. A future version of the specification may do so.
 
-Frames carried in Temporal Units may have coding dependencies on frames carried previously in the same Temporal Unit or in previous Temporal Units. Frames that can be decoded without dependencies to previous frames are of two categories: [=Key Frames=] and [=Intra-only Frames=]. Frames that cannot be decoded independently are of three categories: [=Inter Frames=], [=S Frames=] and frames with a [=show_existing_frame=] flag set to 1.
+Frames carried in Temporal Units may have coding dependencies on frames carried previously in the same Temporal Unit or in previous Temporal Units. Frames that can be decoded without dependencies to previous frames are of two categories: [=Key Frames=] and [=Intra-only Frames=]. Frames that cannot be decoded independently are of three categories: [=Inter Frames=], [=Switch Frames=] and frames with a [=show_existing_frame=] flag set to 1.
 
 Key Frames with the [=show_frame=] flag set to 1 have the additional property that after decoding the Key Frame, all frames can be decoded. They are called [=Random Access Points=] in [[!AV1]].
 
@@ -270,9 +270,9 @@ NOTE: Other types of OBUs such as [=metadata OBUs=] could be present before the 
 
 [=Delayed Random Access Points=] SHOULD be signaled using sample groups and the [=AV1ForwardKeyFrameSampleGroupEntry=].
 
-[=S Frames=] SHOULD be signaled using sample groups and the [=AV1SFrameSampleGroupEntry=].
+[=Switch Frames=] SHOULD be signaled using sample groups and the [=AV1SwitchFrameSampleGroupEntry=].
 
-Additionally, if a file contains multiple tracks which are alternative representations of the same content, in particular using [=S Frames=], those tracks SHOULD be marked as belonging to the same alternate group and should use a track selection box with an appropriate attribute (e.g. 'bitr').
+Additionally, if a file contains multiple tracks which are alternative representations of the same content, in particular using [=Switch Frames=], those tracks SHOULD be marked as belonging to the same alternate group and should use a track selection box with an appropriate attribute (e.g. 'bitr').
 
 Unlike many video standards, AV1 does not distinguish the display order from the decoding order, but achieves similar effects by grouping multiple frames within a sample. Therefore, composition offsets are not used. In tracks using the [=AV1SampleEntry=], the 'ctts' box and composition offsets in movie fragments SHALL NOT be used. Similarly, the is_leading flag, if used, SHALL be set to 0 or 2.
 
@@ -336,10 +336,10 @@ class AV1MultiFrameSampleGroupEntry extends VisualSampleGroupEntry('av1m') {
 }
 ```
 
-AV1 S-Frame sample group entry {#sframeamplegroupentry}
+AV1 Switch Frame sample group entry {#switchframeamplegroupentry}
 -------------------------------------------------------
 
-### Definition ### {#sframeamplegroupentry-definition}
+### Definition ### {#switchframeamplegroupentry-definition}
 
 <pre class="def">
 	Group Type: <dfn export>av1s</dfn>
@@ -349,14 +349,14 @@ AV1 S-Frame sample group entry {#sframeamplegroupentry}
 </pre>
 
 
-### Description ### {#sframeamplegroupentry-description}
+### Description ### {#switchframeamplegroupentry-description}
 
-The <dfn>AV1SFrameSampleGroupEntry</dfn> documents samples that start with an [=S Frame=].
+The <dfn>AV1SwitchFrameSampleGroupEntry</dfn> documents samples that start with a [=Switch Frame=].
 
-### Syntax ### {#sframeamplegroupentry-syntax}
+### Syntax ### {#switchframeamplegroupentry-syntax}
 
 ```
-class AV1SFrameSampleGroupEntry extends VisualSampleGroupEntry('av1s') {
+class AV1SwitchFrameSampleGroupEntry extends VisualSampleGroupEntry('av1s') {
 }
 ```
 

--- a/index.bs
+++ b/index.bs
@@ -256,7 +256,7 @@ For tracks using the [=AV1SampleEntry=], an <dfn>AV1 Sample</dfn> has the follow
 
 NOTE: When extracting OBUs from an ISOBMFF file, and depending on the capabilities of the decoder processing these OBUs, ISOBMFF parsers MAY need to either set the [=obu_has_size_field=] to 1 for some OBUs if not already set and add the length field, or use the length-delimited bitstream format as defined in Annex B of [=AV1=].
 - OBU trailing bits SHOULD be limited to byte alignment and SHOULD not be used for padding,
-- OBUs of type OBU_TD, OBU_PADDING or OBU_REDUNDANT_FRAME_HEADER SHOULD NOT be used.
+- OBUs of type OBU_TEMPORAL_DELIMITER, OBU_PADDING or OBU_REDUNDANT_FRAME_HEADER SHOULD NOT be used.
 
 If an AV1 Sample is signaled as a sync sample (in the SyncSampleBox or by setting sample_is_non_sync_sample to 0), it SHALL be a Random Access Point as defined in [[!AV1]], i.e. satisfy the following constraints:
 - Its first frame is a [=Key Frame=] that has [=show_frame=] flag set to 1,

--- a/index.html
+++ b/index.html
@@ -1611,7 +1611,7 @@ aligned (8) class AV1CodecConfigurationRecord {
     <li data-md="">
      <p>OBU trailing bits SHOULD be limited to byte alignment and SHOULD not be used for padding,</p>
     <li data-md="">
-     <p>OBUs of type OBU_TD, OBU_PADDING or OBU_REDUNDANT_FRAME_HEADER SHOULD NOT be used.</p>
+     <p>OBUs of type OBU_TEMPORAL_DELIMITER, OBU_PADDING or OBU_REDUNDANT_FRAME_HEADER SHOULD NOT be used.</p>
    </ul>
    <p>If an AV1 Sample is signaled as a sync sample (in the SyncSampleBox or by setting sample_is_non_sync_sample to 0), it SHALL be a Random Access Point as defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>, i.e. satisfy the following constraints:</p>
    <ul>

--- a/index.html
+++ b/index.html
@@ -1474,11 +1474,11 @@ pre .property::before, pre .property::after {
         <li><a href="#multiframesamplegroupentry-syntax"><span class="secno">2.7.3</span> <span class="content">Syntax</span></a>
        </ol>
       <li>
-       <a href="#sframeamplegroupentry"><span class="secno">2.8</span> <span class="content">AV1 S-Frame sample group entry</span></a>
+       <a href="#switchframeamplegroupentry"><span class="secno">2.8</span> <span class="content">AV1 Switch Frame sample group entry</span></a>
        <ol class="toc">
-        <li><a href="#sframeamplegroupentry-definition"><span class="secno">2.8.1</span> <span class="content">Definition</span></a>
-        <li><a href="#sframeamplegroupentry-description"><span class="secno">2.8.2</span> <span class="content">Description</span></a>
-        <li><a href="#sframeamplegroupentry-syntax"><span class="secno">2.8.3</span> <span class="content">Syntax</span></a>
+        <li><a href="#switchframeamplegroupentry-definition"><span class="secno">2.8.1</span> <span class="content">Definition</span></a>
+        <li><a href="#switchframeamplegroupentry-description"><span class="secno">2.8.2</span> <span class="content">Description</span></a>
+        <li><a href="#switchframeamplegroupentry-syntax"><span class="secno">2.8.3</span> <span class="content">Syntax</span></a>
        </ol>
       <li>
        <a href="#metadatasamplegroupentry"><span class="secno">2.9</span> <span class="content">AV1 Metadata sample group entry</span></a>
@@ -1516,7 +1516,7 @@ pre .property::before, pre .property::after {
    <p>OBUs are made of a 1 or 2 bytes header, identifying in particular the type of OBU, followed by an optional length field and by an optional payload whose presence and content depend on the OBU type. Depending on its type, an OBU can carry configuration information, metadata or coded video data.</p>
    <p>Temporal Units are processed by a decoder in the order given by the bitstream. Each Temporal Unit is associated with a presentation time. Some Temporal Units may contain multiple frames to be decoded but only one is presented (when scalability is not used).</p>
    <p class="note" role="note"><span>NOTE:</span> The AV1 specification defines scalability features, but this version of storage in ISOBMFF does not specify specific tools for scalability. A future version of the specification may do so.</p>
-   <p>Frames carried in Temporal Units may have coding dependencies on frames carried previously in the same Temporal Unit or in previous Temporal Units. Frames that can be decoded without dependencies to previous frames are of two categories: <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13①">Key Frames</a> and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13②">Intra-only Frames</a>. Frames that cannot be decoded independently are of three categories: <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13③">Inter Frames</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13④">S Frames</a> and frames with a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2">show_existing_frame</a> flag set to 1.</p>
+   <p>Frames carried in Temporal Units may have coding dependencies on frames carried previously in the same Temporal Unit or in previous Temporal Units. Frames that can be decoded without dependencies to previous frames are of two categories: <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13①">Key Frames</a> and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13②">Intra-only Frames</a>. Frames that cannot be decoded independently are of three categories: <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13③">Inter Frames</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13④">Switch Frames</a> and frames with a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2">show_existing_frame</a> flag set to 1.</p>
    <p>Key Frames with the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①">show_frame</a> flag set to 1 have the additional property that after decoding the Key Frame, all frames can be decoded. They are called <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206">Random Access Points</a> in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>.</p>
    <p>Key Frames with the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②">show_frame</a> flag set to 0 are called <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206①">Delayed Random Access Points</a>. <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206②">Delayed Random Access Points</a> have the additional property that if a future <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206③">Key Frame Dependent Recovery Point</a> exists, all frames following that <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206④">Key Frame Dependent Recovery Point</a> can be decoded. A <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑤">Key Frame Dependent Recovery Point</a> is a frame with <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2③">show_existing_frame</a> set to 1 which refers to a previous <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑥">Delayed Random Access Points</a>.</p>
    <h2 class="heading settled" data-level="2" id="basic-encapsulation"><span class="secno">2. </span><span class="content">Basic Encapsulation Scheme</span><a class="self-link" href="#basic-encapsulation"></a></h2>
@@ -1624,8 +1624,8 @@ aligned (8) class AV1CodecConfigurationRecord {
    <p class="note" role="note"><span>NOTE:</span> Other types of OBUs such as <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47①">metadata OBUs</a> could be present before the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑧">Sequence Header OBU</a>.</p>
    <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑦">Intra-only frames</a> SHOULD be signaled using the sample_depends_on flag set to 2.</p>
    <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑦">Delayed Random Access Points</a> SHOULD be signaled using sample groups and the <a data-link-type="dfn" href="#av1forwardkeyframesamplegroupentry" id="ref-for-av1forwardkeyframesamplegroupentry①">AV1ForwardKeyFrameSampleGroupEntry</a>.</p>
-   <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑧">S Frames</a> SHOULD be signaled using sample groups and the <a data-link-type="dfn" href="#av1sframesamplegroupentry" id="ref-for-av1sframesamplegroupentry">AV1SFrameSampleGroupEntry</a>.</p>
-   <p>Additionally, if a file contains multiple tracks which are alternative representations of the same content, in particular using <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑨">S Frames</a>, those tracks SHOULD be marked as belonging to the same alternate group and should use a track selection box with an appropriate attribute (e.g. <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-①①">bitr</a>).</p>
+   <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑧">Switch Frames</a> SHOULD be signaled using sample groups and the <a data-link-type="dfn" href="#av1switchframesamplegroupentry" id="ref-for-av1switchframesamplegroupentry">AV1SwitchFrameSampleGroupEntry</a>.</p>
+   <p>Additionally, if a file contains multiple tracks which are alternative representations of the same content, in particular using <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑨">Switch Frames</a>, those tracks SHOULD be marked as belonging to the same alternate group and should use a track selection box with an appropriate attribute (e.g. <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-①①">bitr</a>).</p>
    <p>Unlike many video standards, AV1 does not distinguish the display order from the decoding order, but achieves similar effects by grouping multiple frames within a sample. Therefore, composition offsets are not used. In tracks using the <a data-link-type="dfn" href="#av1sampleentry" id="ref-for-av1sampleentry③">AV1SampleEntry</a>, the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-①②">ctts</a> box and composition offsets in movie fragments SHALL NOT be used. Similarly, the is_leading flag, if used, SHALL be set to 0 or 2.</p>
    <p>When a temporal unit contains more than one frame, the sample corresponding to that temporal unit MAY be marked using the <a data-link-type="dfn" href="#av1multiframesamplegroupentry" id="ref-for-av1multiframesamplegroupentry">AV1MultiFrameSampleGroupEntry</a>.</p>
    <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47②">Metadata OBUs</a> may be carried in sample data. In this case, the <a data-link-type="dfn" href="#av1metadatasamplegroupentry" id="ref-for-av1metadatasamplegroupentry">AV1MetadataSampleGroupEntry</a> SHOULD be used. If the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47③">metadata OBUs</a> are static for the entire set of samples associated with a given sample description entry, they SHOULD also be in the OBU array in the sample description entry.</p>
@@ -1659,17 +1659,17 @@ Quantity:   Zero or more.
 <pre>class AV1MultiFrameSampleGroupEntry extends VisualSampleGroupEntry('av1m') {
 }
 </pre>
-   <h3 class="heading settled" data-level="2.8" id="sframeamplegroupentry"><span class="secno">2.8. </span><span class="content">AV1 S-Frame sample group entry</span><a class="self-link" href="#sframeamplegroupentry"></a></h3>
-   <h4 class="heading settled" data-level="2.8.1" id="sframeamplegroupentry-definition"><span class="secno">2.8.1. </span><span class="content">Definition</span><a class="self-link" href="#sframeamplegroupentry-definition"></a></h4>
-<pre class="def">Group Type: <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="av1s">av1s</dfn>
+   <h3 class="heading settled" data-level="2.8" id="switchframeamplegroupentry"><span class="secno">2.8. </span><span class="content">AV1 Switch Frame sample group entry</span><a class="self-link" href="#switchframeamplegroupentry"></a></h3>
+   <h4 class="heading settled" data-level="2.8.1" id="switchframeamplegroupentry-definition"><span class="secno">2.8.1. </span><span class="content">Definition</span><a class="self-link" href="#switchframeamplegroupentry-definition"></a></h4>
+<pre class="def">Group Type: <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="av1s">av1s</dfn>
 Container:  Sample Group Description Box ('sgpd')
 Mandatory:  No
 Quantity:   Zero or more.
 </pre>
-   <h4 class="heading settled" data-level="2.8.2" id="sframeamplegroupentry-description"><span class="secno">2.8.2. </span><span class="content">Description</span><a class="self-link" href="#sframeamplegroupentry-description"></a></h4>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1sframesamplegroupentry">AV1SFrameSampleGroupEntry</dfn> documents samples that start with an <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13①⓪">S Frame</a>.</p>
-   <h4 class="heading settled" data-level="2.8.3" id="sframeamplegroupentry-syntax"><span class="secno">2.8.3. </span><span class="content">Syntax</span><a class="self-link" href="#sframeamplegroupentry-syntax"></a></h4>
-<pre>class AV1SFrameSampleGroupEntry extends VisualSampleGroupEntry('av1s') {
+   <h4 class="heading settled" data-level="2.8.2" id="switchframeamplegroupentry-description"><span class="secno">2.8.2. </span><span class="content">Description</span><a class="self-link" href="#switchframeamplegroupentry-description"></a></h4>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="av1switchframesamplegroupentry">AV1SwitchFrameSampleGroupEntry</dfn> documents samples that start with a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13①⓪">Switch Frame</a>.</p>
+   <h4 class="heading settled" data-level="2.8.3" id="switchframeamplegroupentry-syntax"><span class="secno">2.8.3. </span><span class="content">Syntax</span><a class="self-link" href="#switchframeamplegroupentry-syntax"></a></h4>
+<pre>class AV1SwitchFrameSampleGroupEntry extends VisualSampleGroupEntry('av1s') {
 }
 </pre>
    <h3 class="heading settled" data-level="2.9" id="metadatasamplegroupentry"><span class="secno">2.9. </span><span class="content">AV1 Metadata sample group entry</span><a class="self-link" href="#metadatasamplegroupentry"></a></h3>
@@ -1979,7 +1979,7 @@ Quantity:   Zero or more.
    <li><a href="#av1s">av1s</a><span>, in §2.8.1</span>
    <li><a href="#av1-sample">AV1 Sample</a><span>, in §2.5</span>
    <li><a href="#av1sampleentry">AV1SampleEntry</a><span>, in §2.3.2</span>
-   <li><a href="#av1sframesamplegroupentry">AV1SFrameSampleGroupEntry</a><span>, in §2.8.2</span>
+   <li><a href="#av1switchframesamplegroupentry">AV1SwitchFrameSampleGroupEntry</a><span>, in §2.8.2</span>
    <li><a href="#cmaf-av1-track">CMAF AV1 Track</a><span>, in §3</span>
    <li><a href="#compressorname">compressorname</a><span>, in §2.3.4</span>
    <li><a href="#config">config</a><span>, in §2.3.4</span>
@@ -2460,12 +2460,12 @@ Quantity:   Zero or more.
      <li><span class="dfn-paneled" id="term-for-page=2⑦" style="color:initial">obu_size</span>
      <li><span class="dfn-paneled" id="term-for-page=2⑧" style="color:initial">open_bitstream_unit</span>
      <li><span class="dfn-paneled" id="term-for-page=206②" style="color:initial">random access point</span>
-     <li><span class="dfn-paneled" id="term-for-page=13③" style="color:initial">s frame</span>
      <li><span class="dfn-paneled" id="term-for-page=2⑨" style="color:initial">seq_level_idx</span>
      <li><span class="dfn-paneled" id="term-for-page=2①⓪" style="color:initial">seq_tier</span>
      <li><span class="dfn-paneled" id="term-for-page=41" style="color:initial">sequence header obu</span>
      <li><span class="dfn-paneled" id="term-for-page=2①①" style="color:initial">show_existing_frame</span>
      <li><span class="dfn-paneled" id="term-for-page=2①②" style="color:initial">show_frame</span>
+     <li><span class="dfn-paneled" id="term-for-page=13③" style="color:initial">switch frame</span>
      <li><span class="dfn-paneled" id="term-for-page=46" style="color:initial">temporal delimiter obu</span>
      <li><span class="dfn-paneled" id="term-for-page=13④" style="color:initial">temporal unit</span>
      <li><span class="dfn-paneled" id="term-for-page=72" style="color:initial">tile group obu</span>
@@ -2571,10 +2571,10 @@ Quantity:   Zero or more.
     <li><a href="#ref-for-av1s">2.5. AV1 Sample Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="av1sframesamplegroupentry">
-   <b><a href="#av1sframesamplegroupentry">#av1sframesamplegroupentry</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="av1switchframesamplegroupentry">
+   <b><a href="#av1switchframesamplegroupentry">#av1switchframesamplegroupentry</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-av1sframesamplegroupentry">2.5. AV1 Sample Format</a>
+    <li><a href="#ref-for-av1switchframesamplegroupentry">2.5. AV1 Sample Format</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="av1metadatasamplegroupentry">


### PR DESCRIPTION
Some of the terms used are confusing because they don't match what the AV1 spec uses. Here are 2 patch that address obvious ones.

Addresses #49 