### PR TITLE
Add more Sequence Header OBU parameters to AV1CodecConfigurationRecord.

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -2,7 +2,7 @@
 	"AV1": {
 		"href": "http://aomediacodec.github.io/av1-spec/av1-spec.pdf",
 		"title": "AV1 Bitstream & Decoding Process Specification",
-		"status": "LS",
+		"status": "Standard",
 		"publisher": "AOM"
 	},
 	"CMAF": {

--- a/index.bs
+++ b/index.bs
@@ -180,7 +180,7 @@ The <dfn noexport>width</dfn> and <dfn noexport>height</dfn> fields of the [=Vis
 
 The width and height in the TrackHeaderBox SHOULD equal the maximum RenderWidth and RenderHeight values of all the frames associated with this sample entry, respectively called MaxRenderWidth and MaxRenderHeight. Additionally, if MaxRenderWidth and MaxRenderHeight values do not equal respectively the [=max_frame_width_minus_1=] + 1 and [=max_frame_height_minus_1=] + 1 values of the [=Sequence Header OBU=], a PixelAspectRatioBox box SHALL be present in the sample entry and set such that
 ```
-hSpacing / vSpacing = MaxRenderWidth * (max_frame_height_minus_1 + 1)/
+hSpacing / vSpacing = MaxRenderWidth * (max_frame_height_minus_1 + 1) /
                               ((max_frame_width_minus_1 + 1) * MaxRenderHeight)
 ```
 

--- a/index.bs
+++ b/index.bs
@@ -225,7 +225,7 @@ aligned (8) class AV1CodecConfigurationRecord {
   if (initial_presentation_delay_present) {
     unsigned int (4) initial_presentation_delay_minus_one;
   } else {
-    unsigned int (4) reserved;
+    unsigned int (4) reserved = 0;
   }
   unsigned int (1) sequence_parameters_present;
   if (sequence_parameters_present) {

--- a/index.bs
+++ b/index.bs
@@ -6,7 +6,7 @@ Shortname: av1-isobmff
 Editor: Cyril Concolato, Netflix, cconcolato@netflix.com
 Editor: Tom Finegan, Google, tom.finegan@google.com
 Abstract: This document specifies the storage format for [[!AV1]] bitstreams in [[!ISOBMFF]] tracks as well as a set of [[!CMAF]] Media profiles based on [[!AV1]].
-Date: 2018-07-18
+Date: 2018-08-07
 Repository: AOMediaCodec/av1-isobmff
 Inline Github Issues: full
 Boilerplate: property-index no, issues-index no, copyright yes
@@ -104,6 +104,7 @@ url: http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2; spec: AV1; type
 	text: obu_has_size_field
 	text: obu_size
 	text: open_bitstream_unit
+	text: seq_profile
 	text: seq_level_idx
 	text: seq_tier
 	text: show_existing_frame
@@ -113,6 +114,8 @@ url: http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2; spec: AV1; type
 	text: byte_alignment
 	text: frame_presentation_time
 	text: initial_display_delay_minus_1
+	text: still_picture
+	text: mono_chrome
 </pre>
 
 Bitstream features overview {#bitstream-overview}
@@ -175,7 +178,7 @@ class AV1SampleEntry extends VisualSampleEntry('av01') {
 
 The <dfn noexport>width</dfn> and <dfn noexport>height</dfn> fields of the [=VisualSampleEntry=] SHALL equal the values of [=max_frame_width_minus_1=] + 1 and [=max_frame_height_minus_1=] + 1 of the [=Sequence Header OBU=] applying to the samples associated with this sample entry.
 
-The width and height in the TrackHeaderBox SHOULD equal the maximum RenderWidth and RenderHeight values of all the frames associated with this sample entry, respectively called MaxRenderWidth and MaxRenderHeight. Additionally, if MaxRenderWidth and MaxRenderHeight values do not equal respectively the [=max_frame_width_minus_1=] + 1 and [=max_frame_height_minus_1=] + 1 values of the [=Sequence Header OBU=], a PixelAspectRatioBox box SHALL be present in the sample entry and set such that 
+The width and height in the TrackHeaderBox SHOULD equal the maximum RenderWidth and RenderHeight values of all the frames associated with this sample entry, respectively called MaxRenderWidth and MaxRenderHeight. Additionally, if MaxRenderWidth and MaxRenderHeight values do not equal respectively the [=max_frame_width_minus_1=] + 1 and [=max_frame_height_minus_1=] + 1 values of the [=Sequence Header OBU=], a PixelAspectRatioBox box SHALL be present in the sample entry and set such that
 ```
 hSpacing / vSpacing = MaxRenderWidth * (max_frame_height_minus_1 + 1)/
                               ((max_frame_width_minus_1 + 1) * MaxRenderHeight)
@@ -217,12 +220,16 @@ class AV1CodecConfigurationBox extends FullBox('av1C', version = 0, 0){
 }
 
 aligned (8) class AV1CodecConfigurationRecord {
-  unsigned int (3) reserved = 0;
-  unsigned int (1) initial_presentation_delay_present;
-  if (initial_presentation_delay_present) {
-    unsigned int (4) initial_presentation_delay_minus_one;
+  unsigned int (1) sequence_parameters_present;
+  if (sequence_parameters_present) {
+    unsigned int (3) seq_profile;
+    unsigned int (1) still_picture;
+    unsigned int (5) seq_level_idx_0;
+    unsigned int (1) seq_tier_0;
+    unsigned int (4) bit_depth;
+    unsigned int (1) monochrome;
   } else {
-    unsigned int (4) reserved;
+    unsigned int (15) reserved;
   }
   unsigned int (8)[] configOBUs;
 }
@@ -238,15 +245,14 @@ NOTE: The configOBUs field is expected to contain only OBU_SEQUENCE_HEADER and O
 
 OBUs stored in the configOBUs field follow the [=open_bitstream_unit=] [=Low Overhead Bitstream Format=] syntax as specified in [[!AV1]]. The flag [=obu_has_size_field=] SHALL be set to 1, indicating that the size of the OBU payload follows the header, and that it is coded using LEB128.
 
-The <dfn>initial_presentation_delay_present</dfn> field indicates the presence of the initial_presentation_delay_minus_one field.
+The <dfn export>sequence_parameters_present</dfn> field indicates the presence of the parameters [=seq_profile=], [=still_picture=], [=seq_level_idx_0=], [=seq_tier_0=], [=bit_depth=], and [=monochrome=] fields from the AV1 [=Sequence Header OBU=].
 
-The <dfn>initial_presentation_delay_minus_one</dfn> field indicates the number of samples (minus one) that need be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by [=seq_level_idx=] in the [=Sequence Header OBU=] (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:
-- construct a hypothetical bitstream consisting of the OBUs carried in the sample entry followed by the OBUs carried in all the samples,
-- set the first [=initial_display_delay_minus_1=] field of each [=Sequence Header OBU=] to the number of frames contained in the first [=initial_presentation_delay_minus_one=] + 1 samples,
-- set the [=frame_presentation_time=] field of the frame header of each presentable frame such that it matches the presentation time difference between the sample carrying this frame and the previous sample (if it exists, 0 otherwise),
-- apply the display model verification algorithm.
-
-When smooth presentation can be guaranteed after decoding the first sample, the value 0 SHALL be used. If an ISOBMFF writer cannot verify the above procedure, [=initial_presentation_delay_present=] SHALL be set to 0.
+- <dfn>seq_profile</dfn> indicates the AV1 profile and SHALL be equal to the seq_profile value from the [=Sequence Header OBU=].
+- <dfn>still_picture</dfn> indicates the value of the still_picture field found in the [=Sequence Header OBU=] and SHALL be equal to the value from the [=Sequence Header OBU=].
+- <dfn>seq_level_idx_0</dfn> indicates the value of seq_level_idx[0] found in the [=Sequence Header OBU=] and SHALL be equal to the value of seq_level_idx[0] in the [=Sequence Header OBU=].
+- <dfn>seq_tier_0</dfn> indicates the value of seq_tier[0] found in the [=Sequence Header OBU=] and SHALL be equal to the value of seq_tier[0] in the [=Sequence Header OBU=].
+- <dfn>bit_depth</dfn> indicates the bit depth of pixel components within the output samples from the AV1 bitstream. The value MUST be 8, 10, or 12.
+- <dfn>monochrome</dfn> indicates the value of the [=mono_chrome=] flag from the [=Sequence Header OBU=].
 
 The presentation times of AV1 samples are given by the ISOBMFF structures. The [=timing_info_present_flag=] in the [=Sequence Header OBU=] (in the configOBUs field or in the associated samples) SHOULD be set to 0. If set to 1, the [=timing_info=] structure of the [=Sequence Header OBU=], the [=frame_presentation_time=] and [=buffer_removal_time=] fields of the [=Frame Header OBUs=], if present, SHALL be ignored for the purpose of timed processing of the ISOBMFF file.
 

--- a/index.bs
+++ b/index.bs
@@ -215,11 +215,18 @@ The <dfn>AV1CodecConfigurationBox</dfn> contains decoder configuration informati
 ### Syntax ### {#av1codecconfigurationbox-syntax}
 
 ```
-class AV1CodecConfigurationBox extends FullBox('av1C', version = 0, 0){
+class AV1CodecConfigurationBox extends FullBox('av1C', version = 1, 0){
   AV1CodecConfigurationRecord av1Config;
 }
 
 aligned (8) class AV1CodecConfigurationRecord {
+  unsigned int (5) reserved = 0;
+  unsigned int (1) initial_presentation_delay_present;
+  if (initial_presentation_delay_present) {
+    unsigned int (4) initial_presentation_delay_minus_one;
+  } else {
+    unsigned int (4) reserved;
+  }
   unsigned int (1) sequence_parameters_present;
   if (sequence_parameters_present) {
     unsigned int (3) seq_profile;
@@ -227,9 +234,8 @@ aligned (8) class AV1CodecConfigurationRecord {
     unsigned int (5) seq_level_idx_0;
     unsigned int (1) seq_tier_0;
     unsigned int (4) bit_depth;
-    unsigned int (1) monochrome;
   } else {
-    unsigned int (15) reserved;
+    unsigned int (14) reserved = 0;
   }
   unsigned int (8)[] configOBUs;
 }
@@ -245,14 +251,25 @@ NOTE: The configOBUs field is expected to contain only OBU_SEQUENCE_HEADER and O
 
 OBUs stored in the configOBUs field follow the [=open_bitstream_unit=] [=Low Overhead Bitstream Format=] syntax as specified in [[!AV1]]. The flag [=obu_has_size_field=] SHALL be set to 1, indicating that the size of the OBU payload follows the header, and that it is coded using LEB128.
 
-The <dfn export>sequence_parameters_present</dfn> field indicates the presence of the parameters [=seq_profile=], [=still_picture=], [=seq_level_idx_0=], [=seq_tier_0=], [=bit_depth=], and [=monochrome=] fields from the AV1 [=Sequence Header OBU=].
+The <dfn>initial_presentation_delay_present</dfn> field indicates the presence of the initial_presentation_delay_minus_one field.
+
+The <dfn>initial_presentation_delay_minus_one</dfn> field indicates the number of samples (minus one) that need be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by [=seq_level_idx=] in the [=Sequence Header OBU=] (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:
+- construct a hypothetical bitstream consisting of the OBUs carried in the sample entry followed by the OBUs carried in all the samples,
+- set the first [=initial_display_delay_minus_1=] field of each [=Sequence Header OBU=] to the number of frames contained in the first [=initial_presentation_delay_minus_one=] + 1 samples,
+- set the [=frame_presentation_time=] field of the frame header of each presentable frame such that it matches the presentation time difference between the sample carrying this frame and the previous sample (if it exists, 0 otherwise),
+- apply the display model verification algorithm.
+
+When smooth presentation can be guaranteed after decoding the first sample, the value 0 SHALL be used. If an ISOBMFF writer cannot verify the above procedure, [=initial_presentation_delay_present=] SHALL be set to 0.
+
+The <dfn export>sequence_parameters_present</dfn> field indicates the presence of the parameters [=seq_profile=], [=still_picture=], [=seq_level_idx_0=], [=seq_tier_0=], and [=bit_depth=] fields from the AV1 [=Sequence Header OBU=].
 
 - <dfn>seq_profile</dfn> indicates the AV1 profile and SHALL be equal to the seq_profile value from the [=Sequence Header OBU=].
 - <dfn>still_picture</dfn> indicates the value of the still_picture field found in the [=Sequence Header OBU=] and SHALL be equal to the value from the [=Sequence Header OBU=].
 - <dfn>seq_level_idx_0</dfn> indicates the value of seq_level_idx[0] found in the [=Sequence Header OBU=] and SHALL be equal to the value of seq_level_idx[0] in the [=Sequence Header OBU=].
 - <dfn>seq_tier_0</dfn> indicates the value of seq_tier[0] found in the [=Sequence Header OBU=] and SHALL be equal to the value of seq_tier[0] in the [=Sequence Header OBU=].
 - <dfn>bit_depth</dfn> indicates the bit depth of pixel components within the output samples from the AV1 bitstream. The value MUST be 8, 10, or 12.
-- <dfn>monochrome</dfn> indicates the value of the [=mono_chrome=] flag from the [=Sequence Header OBU=].
+
+When the AV1CodecConfigurationRecord indicates that fields from the [=Sequence Header OBU=] are present via [=sequence_parameters_present=], and a [=Sequence Header OBU=] is present within the configOBUs, the values present in the [=Sequence Header OBU=] contained within configOBUs SHALL match the values of the AV1CodecConfigurationRecord sequence parameters.
 
 The presentation times of AV1 samples are given by the ISOBMFF structures. The [=timing_info_present_flag=] in the [=Sequence Header OBU=] (in the configOBUs field or in the associated samples) SHOULD be set to 0. If set to 1, the [=timing_info=] structure of the [=Sequence Header OBU=], the [=frame_presentation_time=] and [=buffer_removal_time=] fields of the [=Frame Header OBUs=], if present, SHALL be ignored for the purpose of timed processing of the ISOBMFF file.
 

--- a/index.bs
+++ b/index.bs
@@ -264,7 +264,7 @@ The <dfn>initial_presentation_delay_minus_one</dfn> field indicates the number o
 
 When smooth presentation can be guaranteed after decoding the first sample, the value 0 SHALL be used. If an ISOBMFF writer cannot verify the above procedure, [=initial_presentation_delay_present=] SHALL be set to 0.
 
-The <dfn export>sequence_parameters_present</dfn> field indicates the presence of the parameters [=seq_profile=], [=still_picture=], [=seq_level_idx_0=], [=seq_tier_0=], and [=bit_depth=] fields from the AV1 [=Sequence Header OBU=].
+The <dfn export>sequence_parameters_present</dfn> field indicates the presence of  parameters from the [=Sequence Header OBU=], either present in the configOBUs field or in the associated samples.
 
 - <dfn export>seq_profile</dfn> indicates the AV1 profile and SHALL be equal to the seq_profile value from the [=Sequence Header OBU=].
 - <dfn export>still_picture</dfn> indicates the value of the still_picture field found in the [=Sequence Header OBU=] and SHALL be equal to the value from the [=Sequence Header OBU=].

--- a/index.bs
+++ b/index.bs
@@ -215,12 +215,12 @@ The <dfn>AV1CodecConfigurationBox</dfn> contains decoder configuration informati
 ### Syntax ### {#av1codecconfigurationbox-syntax}
 
 ```
-class AV1CodecConfigurationBox extends FullBox('av1C', version = 1, 0){
-  AV1CodecConfigurationRecord av1Config;
+class AV1CodecConfigurationBox extends FullBox('av1C', version = 0, 0){
+  AV1CodecConfigurationRecordv1 av1Config;
 }
 
-aligned (8) class AV1CodecConfigurationRecord {
-  unsigned int (5) reserved = 0;
+aligned (8) class AV1CodecConfigurationRecordv1 {
+  unsigned int (4) reserved = 0;
   unsigned int (1) initial_presentation_delay_present;
   if (initial_presentation_delay_present) {
     unsigned int (4) initial_presentation_delay_minus_one;
@@ -242,6 +242,8 @@ aligned (8) class AV1CodecConfigurationRecord {
 ```
 
 ### Semantics ### {#av1codecconfigurationbox-semantics}
+
+Previous versions of this specification defined AV1CodecConfigurationRecord. Use of AV1CodecConfigurationRecord is deprecated.
 
 The <dfn export>configOBUs</dfn> field contains zero or more OBUs. Any OBU may be present provided that the following procedures produce compliant AV1 bitstreams:
 - From any sync sample, an AV1 bitstream is formed by first outputting the OBUs contained in the [=AV1CodecConfigurationBox=] and then by outputing all OBUs in the samples themselves, in order, starting from the sync sample.
@@ -269,7 +271,7 @@ The <dfn export>sequence_parameters_present</dfn> field indicates the presence o
 - <dfn>seq_tier_0</dfn> indicates the value of seq_tier[0] found in the [=Sequence Header OBU=] and SHALL be equal to the value of seq_tier[0] in the [=Sequence Header OBU=].
 - <dfn>bit_depth</dfn> indicates the bit depth of pixel components within the output samples from the AV1 bitstream. The value MUST be 8, 10, or 12.
 
-When the AV1CodecConfigurationRecord indicates that fields from the [=Sequence Header OBU=] are present via [=sequence_parameters_present=], and a [=Sequence Header OBU=] is present within the configOBUs, the values present in the [=Sequence Header OBU=] contained within configOBUs SHALL match the values of the AV1CodecConfigurationRecord sequence parameters.
+When the AV1CodecConfigurationRecordv1 indicates that fields from the [=Sequence Header OBU=] are present via [=sequence_parameters_present=], and a [=Sequence Header OBU=] is present within the configOBUs, the values present in the [=Sequence Header OBU=] contained within configOBUs SHALL match the values of the AV1CodecConfigurationRecordv1 sequence parameters.
 
 The presentation times of AV1 samples are given by the ISOBMFF structures. The [=timing_info_present_flag=] in the [=Sequence Header OBU=] (in the configOBUs field or in the associated samples) SHOULD be set to 0. If set to 1, the [=timing_info=] structure of the [=Sequence Header OBU=], the [=frame_presentation_time=] and [=buffer_removal_time=] fields of the [=Frame Header OBUs=], if present, SHALL be ignored for the purpose of timed processing of the ISOBMFF file.
 

--- a/index.bs
+++ b/index.bs
@@ -6,7 +6,7 @@ Shortname: av1-isobmff
 Editor: Cyril Concolato, Netflix, cconcolato@netflix.com
 Editor: Tom Finegan, Google, tom.finegan@google.com
 Abstract: This document specifies the storage format for [[!AV1]] bitstreams in [[!ISOBMFF]] tracks as well as a set of [[!CMAF]] Media profiles based on [[!AV1]].
-Date: 2018-08-07
+Date: 2018-08-09
 Repository: AOMediaCodec/av1-isobmff
 Inline Github Issues: full
 Boilerplate: property-index no, issues-index no, copyright yes
@@ -116,6 +116,8 @@ url: http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2; spec: AV1; type
 	text: initial_display_delay_minus_1
 	text: still_picture
 	text: mono_chrome
+	text: subsampling_x
+	text: subsampling_y
 </pre>
 
 Bitstream features overview {#bitstream-overview}
@@ -221,6 +223,7 @@ class AV1CodecConfigurationBox extends FullBox('av1C', version = 0, 0){
 
 aligned (8) class AV1CodecConfigurationRecordv1 {
   unsigned int (4) reserved = 0;
+  unsigned int (3) version;
   unsigned int (1) initial_presentation_delay_present;
   if (initial_presentation_delay_present) {
     unsigned int (4) initial_presentation_delay_minus_one;
@@ -234,8 +237,12 @@ aligned (8) class AV1CodecConfigurationRecordv1 {
     unsigned int (5) seq_level_idx_0;
     unsigned int (1) seq_tier_0;
     unsigned int (4) bit_depth;
+    unsigned int (1) monochrome;
+    unsigned int (1) chroma_subsampling_x;
+    unsigned int (1) chroma_subsampling_y;
+    unsigned int (2) chroma_sample_position;
   } else {
-    unsigned int (14) reserved = 0;
+    unsigned int (19) reserved = 0;
   }
   unsigned int (8)[] configOBUs;
 }
@@ -243,15 +250,9 @@ aligned (8) class AV1CodecConfigurationRecordv1 {
 
 ### Semantics ### {#av1codecconfigurationbox-semantics}
 
-Previous versions of this specification defined AV1CodecConfigurationRecord. Use of AV1CodecConfigurationRecord is deprecated.
+Previous versions of this specification defined v0 of the AV1CodecConfigurationRecord. Use of AV1CodecConfigurationRecord v0 is deprecated.
 
-The <dfn export>configOBUs</dfn> field contains zero or more OBUs. Any OBU may be present provided that the following procedures produce compliant AV1 bitstreams:
-- From any sync sample, an AV1 bitstream is formed by first outputting the OBUs contained in the [=AV1CodecConfigurationBox=] and then by outputing all OBUs in the samples themselves, in order, starting from the sync sample.
-- From any sample marked with the [=AV1ForwardKeyFrameSampleGroupEntry=], an AV1 bitstream is formed by first outputting the OBUs contained in the [=AV1CodecConfigurationBox=] and then by outputing all OBUs in the sample itself, then by outputting all OBUs in the samples, in order, starting from the sample at the distance indicated by the sample group.
-
-NOTE: The configOBUs field is expected to contain only OBU_SEQUENCE_HEADER and OBU_METADATA when the [=metadata OBU=] is applicable to all the associated samples.
-
-OBUs stored in the configOBUs field follow the [=open_bitstream_unit=] [=Low Overhead Bitstream Format=] syntax as specified in [[!AV1]]. The flag [=obu_has_size_field=] SHALL be set to 1, indicating that the size of the OBU payload follows the header, and that it is coded using LEB128.
+The <dfn noexport>version</dfn> field indicates the version of the AV1CodecConfigurationRecordv1. The value SHALL be set to 1 for AV1CodecConfigurationRecordv1.
 
 The <dfn>initial_presentation_delay_present</dfn> field indicates the presence of the initial_presentation_delay_minus_one field.
 
@@ -265,17 +266,31 @@ When smooth presentation can be guaranteed after decoding the first sample, the 
 
 The <dfn export>sequence_parameters_present</dfn> field indicates the presence of the parameters [=seq_profile=], [=still_picture=], [=seq_level_idx_0=], [=seq_tier_0=], and [=bit_depth=] fields from the AV1 [=Sequence Header OBU=].
 
-- <dfn>seq_profile</dfn> indicates the AV1 profile and SHALL be equal to the seq_profile value from the [=Sequence Header OBU=].
-- <dfn>still_picture</dfn> indicates the value of the still_picture field found in the [=Sequence Header OBU=] and SHALL be equal to the value from the [=Sequence Header OBU=].
-- <dfn>seq_level_idx_0</dfn> indicates the value of seq_level_idx[0] found in the [=Sequence Header OBU=] and SHALL be equal to the value of seq_level_idx[0] in the [=Sequence Header OBU=].
-- <dfn>seq_tier_0</dfn> indicates the value of seq_tier[0] found in the [=Sequence Header OBU=] and SHALL be equal to the value of seq_tier[0] in the [=Sequence Header OBU=].
-- <dfn>bit_depth</dfn> indicates the bit depth of pixel components within the output samples from the AV1 bitstream. The value MUST be 8, 10, or 12.
+- <dfn export>seq_profile</dfn> indicates the AV1 profile and SHALL be equal to the seq_profile value from the [=Sequence Header OBU=].
+- <dfn export>still_picture</dfn> indicates the value of the still_picture field found in the [=Sequence Header OBU=] and SHALL be equal to the value from the [=Sequence Header OBU=].
+- <dfn export>seq_level_idx_0</dfn> indicates the value of seq_level_idx[0] found in the [=Sequence Header OBU=] and SHALL be equal to the value of seq_level_idx[0] in the [=Sequence Header OBU=].
+- <dfn export>seq_tier_0</dfn> indicates the value of seq_tier[0] found in the [=Sequence Header OBU=] and SHALL be equal to the value of seq_tier[0] in the [=Sequence Header OBU=].
+- <dfn export>bit_depth</dfn> indicates the bit depth of pixel components within the output samples from the AV1 bitstream. The value MUST be 8, 10, or 12.
+- <dfn export>monochrome</dfn> indicates the value of the [=mono_chrome=] flag from the [=Sequence Header OBU=].
+- <dfn export>chroma_subsampling_x</dfn> indicates the [=subsampling_x=] value from the [=Sequence Header OBU=].
+- <dfn export>chroma_subsampling_y</dfn> indicates the [=subsampling_y=] value from the [=Sequence Header OBU=].
+- <dfn export>chroma_sample_position</dfn> indicates the [=chroma_sample_position=] value from the [=Sequence Header OBU=].
 
 When the AV1CodecConfigurationRecordv1 indicates that fields from the [=Sequence Header OBU=] are present via [=sequence_parameters_present=], and a [=Sequence Header OBU=] is present within the configOBUs, the values present in the [=Sequence Header OBU=] contained within configOBUs SHALL match the values of the AV1CodecConfigurationRecordv1 sequence parameters.
+
+The <dfn export>configOBUs</dfn> field contains zero or more OBUs. Any OBU may be present provided that the following procedures produce compliant AV1 bitstreams:
+- From any sync sample, an AV1 bitstream is formed by first outputting the OBUs contained in the [=AV1CodecConfigurationBox=] and then by outputing all OBUs in the samples themselves, in order, starting from the sync sample.
+- From any sample marked with the [=AV1ForwardKeyFrameSampleGroupEntry=], an AV1 bitstream is formed by first outputting the OBUs contained in the [=AV1CodecConfigurationBox=] and then by outputing all OBUs in the sample itself, then by outputting all OBUs in the samples, in order, starting from the sample at the distance indicated by the sample group.
+
+NOTE: The configOBUs field is expected to contain only OBU_SEQUENCE_HEADER and OBU_METADATA when the [=metadata OBU=] is applicable to all the associated samples.
+
+OBUs stored in the configOBUs field follow the [=open_bitstream_unit=] [=Low Overhead Bitstream Format=] syntax as specified in [[!AV1]]. The flag [=obu_has_size_field=] SHALL be set to 1, indicating that the size of the OBU payload follows the header, and that it is coded using LEB128.
 
 The presentation times of AV1 samples are given by the ISOBMFF structures. The [=timing_info_present_flag=] in the [=Sequence Header OBU=] (in the configOBUs field or in the associated samples) SHOULD be set to 0. If set to 1, the [=timing_info=] structure of the [=Sequence Header OBU=], the [=frame_presentation_time=] and [=buffer_removal_time=] fields of the [=Frame Header OBUs=], if present, SHALL be ignored for the purpose of timed processing of the ISOBMFF file.
 
 If a 'colr' box is present in the [=VisualSampleEntry=] with a colour_type set to 'nclx', the values of colour_primaries, transfer_characteristics, and matrix_coefficients SHALL match the values given in the [=Sequence Header OBU=] (in the configOBUs field or in the associated samples) if the color_description_present_flag is set to 1. Similarly, the full_range_flag in the 'colr' box shall match the color_range flag in the [=Sequence Header OBU=].
+
+When configOBUs does not contain a [=Sequence Header OBU=] a 'colr' box SHALL be present in the [=VisualSampleEntry=] with colour_type set to 'nclx'.
 
 Additional boxes may be provided at the end of the [=VisualSampleEntry=] as permitted by ISOBMFF, that may represent redundant or similar information to the one provided in some OBUs contained in the [=AV1CodecConfigurationBox=]. If the box definition does not indicate that its information overrides the OBU information, in case of conflict, the OBU information should be considered authoritative.
 

--- a/index.bs
+++ b/index.bs
@@ -223,7 +223,7 @@ class AV1CodecConfigurationBox extends FullBox('av1C', version = 0, 0){
 
 aligned (8) class AV1CodecConfigurationRecordv1 {
   unsigned int (4) reserved = 0;
-  unsigned int (3) version;
+  unsigned int (3) version = 1;
   unsigned int (1) initial_presentation_delay_present;
   if (initial_presentation_delay_present) {
     unsigned int (4) initial_presentation_delay_minus_one;

--- a/index.html
+++ b/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 0e8880531a1904b4bc0b037759fa3cb386293992" name="generator">
   <link href="https://AOMediaCodec.github.io/av1-isobmff" rel="canonical">
-  <meta content="c2f164deb29f674b4512c2428171413259dcad57" name="document-revision">
+  <meta content="f9d6560d5e6d71fb33e9c593f885109377b7c8c4" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1563,12 +1563,12 @@ Quantity:  Exactly One
    <h4 class="heading settled" data-level="2.4.2" id="av1codecconfigurationbox-description"><span class="secno">2.4.2. </span><span class="content">Description</span><a class="self-link" href="#av1codecconfigurationbox-description"></a></h4>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1codecconfigurationbox">AV1CodecConfigurationBox</dfn> contains decoder configuration information that SHALL be valid for every sample that references the sample entry.</p>
    <h4 class="heading settled" data-level="2.4.3" id="av1codecconfigurationbox-syntax"><span class="secno">2.4.3. </span><span class="content">Syntax</span><a class="self-link" href="#av1codecconfigurationbox-syntax"></a></h4>
-<pre>class AV1CodecConfigurationBox extends FullBox('av1C', version = 1, 0){
-  AV1CodecConfigurationRecord av1Config;
+<pre>class AV1CodecConfigurationBox extends FullBox('av1C', version = 0, 0){
+  AV1CodecConfigurationRecordv1 av1Config;
 }
 
-aligned (8) class AV1CodecConfigurationRecord {
-  unsigned int (5) reserved = 0;
+aligned (8) class AV1CodecConfigurationRecordv1 {
+  unsigned int (4) reserved = 0;
   unsigned int (1) initial_presentation_delay_present;
   if (initial_presentation_delay_present) {
     unsigned int (4) initial_presentation_delay_minus_one;
@@ -1589,6 +1589,7 @@ aligned (8) class AV1CodecConfigurationRecord {
 }
 </pre>
    <h4 class="heading settled" data-level="2.4.4" id="av1codecconfigurationbox-semantics"><span class="secno">2.4.4. </span><span class="content">Semantics</span><a class="self-link" href="#av1codecconfigurationbox-semantics"></a></h4>
+   <p>Previous versions of this specification defined AV1CodecConfigurationRecord. Use of AV1CodecConfigurationRecord is deprecated.</p>
    <p>The <dfn data-dfn-type="dfn" data-export="" id="configobus">configOBUs<a class="self-link" href="#configobus"></a></dfn> field contains zero or more OBUs. Any OBU may be present provided that the following procedures produce compliant AV1 bitstreams:</p>
    <ul>
     <li data-md="">
@@ -1624,7 +1625,7 @@ aligned (8) class AV1CodecConfigurationRecord {
     <li data-md="">
      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="bit_depth">bit_depth</dfn> indicates the bit depth of pixel components within the output samples from the AV1 bitstream. The value MUST be 8, 10, or 12.</p>
    </ul>
-   <p>When the AV1CodecConfigurationRecord indicates that fields from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①②">Sequence Header OBU</a> are present via <a data-link-type="dfn" href="#sequence_parameters_present" id="ref-for-sequence_parameters_present">sequence_parameters_present</a>, and a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①③">Sequence Header OBU</a> is present within the configOBUs, the values present in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①④">Sequence Header OBU</a> contained within configOBUs SHALL match the values of the AV1CodecConfigurationRecord sequence parameters.</p>
+   <p>When the AV1CodecConfigurationRecordv1 indicates that fields from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①②">Sequence Header OBU</a> are present via <a data-link-type="dfn" href="#sequence_parameters_present" id="ref-for-sequence_parameters_present">sequence_parameters_present</a>, and a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①③">Sequence Header OBU</a> is present within the configOBUs, the values present in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①④">Sequence Header OBU</a> contained within configOBUs SHALL match the values of the AV1CodecConfigurationRecordv1 sequence parameters.</p>
    <p>The presentation times of AV1 samples are given by the ISOBMFF structures. The <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①③">timing_info_present_flag</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑤">Sequence Header OBU</a> (in the configOBUs field or in the associated samples) SHOULD be set to 0. If set to 1, the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=45" id="ref-for-page=45">timing_info</a> structure of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑥">Sequence Header OBU</a>, the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①④">frame_presentation_time</a> and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑤">buffer_removal_time</a> fields of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49">Frame Header OBUs</a>, if present, SHALL be ignored for the purpose of timed processing of the ISOBMFF file.</p>
    <p>If a <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-③">colr</a> box is present in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④">VisualSampleEntry</a> with a colour_type set to <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑤">nclx</a>, the values of colour_primaries, transfer_characteristics, and matrix_coefficients SHALL match the values given in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑦">Sequence Header OBU</a> (in the configOBUs field or in the associated samples) if the color_description_present_flag is set to 1. Similarly, the full_range_flag in the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑥">colr</a> box shall match the color_range flag in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑧">Sequence Header OBU</a>.</p>
    <p>Additional boxes may be provided at the end of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-⑦">VisualSampleEntry</a> as permitted by ISOBMFF, that may represent redundant or similar information to the one provided in some OBUs contained in the <a data-link-type="dfn" href="#av1codecconfigurationbox" id="ref-for-av1codecconfigurationbox⑤">AV1CodecConfigurationBox</a>. If the box definition does not indicate that its information overrides the OBU information, in case of conflict, the OBU information should be considered authoritative.</p>

--- a/index.html
+++ b/index.html
@@ -1211,9 +1211,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version dc6a0999286e5dda761ab3caeb4f978c270ddaf8" name="generator">
+  <meta content="Bikeshed version 0e8880531a1904b4bc0b037759fa3cb386293992" name="generator">
   <link href="https://AOMediaCodec.github.io/av1-isobmff" rel="canonical">
-  <meta content="7ef72497ccee9c745653cae5ae6cbb7fd4312ea6" name="document-revision">
+  <meta content="6bb5bd7fcd336b194c2fd5812733e01f5b79dad8" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1402,7 +1402,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">AV1 Codec ISO Media File Format Binding</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2018-07-18">18 July 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2018-08-07">7 August 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1568,12 +1568,16 @@ Quantity:  Exactly One
 }
 
 aligned (8) class AV1CodecConfigurationRecord {
-  unsigned int (3) reserved = 0;
-  unsigned int (1) initial_presentation_delay_present;
-  if (initial_presentation_delay_present) {
-    unsigned int (4) initial_presentation_delay_minus_one;
+  unsigned int (1) sequence_parameters_present;
+  if (sequence_parameters_present) {
+    unsigned int (3) seq_profile;
+    unsigned int (1) still_picture;
+    unsigned int (5) seq_level_idx_0;
+    unsigned int (1) seq_tier_0;
+    unsigned int (4) bit_depth;
+    unsigned int (1) monochrome;
   } else {
-    unsigned int (4) reserved;
+    unsigned int (15) reserved;
   }
   unsigned int (8)[] configOBUs;
 }
@@ -1588,21 +1592,23 @@ aligned (8) class AV1CodecConfigurationRecord {
    </ul>
    <p class="note" role="note"><span>NOTE:</span> The configOBUs field is expected to contain only OBU_SEQUENCE_HEADER and OBU_METADATA when the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47">metadata OBU</a> is applicable to all the associated samples.</p>
    <p>OBUs stored in the configOBUs field follow the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑧">open_bitstream_unit</a> <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39①">Low Overhead Bitstream Format</a> syntax as specified in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>. The flag <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑨">obu_has_size_field</a> SHALL be set to 1, indicating that the size of the OBU payload follows the header, and that it is coded using LEB128.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="initial_presentation_delay_present">initial_presentation_delay_present</dfn> field indicates the presence of the initial_presentation_delay_minus_one field.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</dfn> field indicates the number of samples (minus one) that need be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⓪">seq_level_idx</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②">Sequence Header OBU</a> (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:</p>
+   <p>The <dfn data-dfn-type="dfn" data-export="" id="sequence_parameters_present">sequence_parameters_present<a class="self-link" href="#sequence_parameters_present"></a></dfn> field indicates the presence of the parameters <a data-link-type="dfn" href="#seq_profile" id="ref-for-seq_profile">seq_profile</a>, <a data-link-type="dfn" href="#still_picture" id="ref-for-still_picture">still_picture</a>, <a data-link-type="dfn" href="#seq_level_idx_0" id="ref-for-seq_level_idx_0">seq_level_idx_0</a>, <a data-link-type="dfn" href="#seq_tier_0" id="ref-for-seq_tier_0">seq_tier_0</a>, <a data-link-type="dfn" href="#bit_depth" id="ref-for-bit_depth">bit_depth</a>, and <a data-link-type="dfn" href="#monochrome" id="ref-for-monochrome">monochrome</a> fields from the AV1 <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②">Sequence Header OBU</a>.</p>
    <ul>
     <li data-md="">
-     <p>construct a hypothetical bitstream consisting of the OBUs carried in the sample entry followed by the OBUs carried in all the samples,</p>
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="seq_profile">seq_profile</dfn> indicates the AV1 profile and SHALL be equal to the seq_profile value from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41③">Sequence Header OBU</a>.</p>
     <li data-md="">
-     <p>set the first <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①①">initial_display_delay_minus_1</a> field of each <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41③">Sequence Header OBU</a> to the number of frames contained in the first <a data-link-type="dfn" href="#initial_presentation_delay_minus_one" id="ref-for-initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</a> + 1 samples,</p>
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="still_picture">still_picture</dfn> indicates the value of the still_picture field found in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41④">Sequence Header OBU</a> and SHALL be equal to the value from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑤">Sequence Header OBU</a>.</p>
     <li data-md="">
-     <p>set the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①②">frame_presentation_time</a> field of the frame header of each presentable frame such that it matches the presentation time difference between the sample carrying this frame and the previous sample (if it exists, 0 otherwise),</p>
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="seq_level_idx_0">seq_level_idx_0</dfn> indicates the value of seq_level_idx[0] found in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑥">Sequence Header OBU</a> and SHALL be equal to the value of seq_level_idx[0] in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑦">Sequence Header OBU</a>.</p>
     <li data-md="">
-     <p>apply the display model verification algorithm.</p>
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="seq_tier_0">seq_tier_0</dfn> indicates the value of seq_tier[0] found in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑧">Sequence Header OBU</a> and SHALL be equal to the value of seq_tier[0] in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑨">Sequence Header OBU</a>.</p>
+    <li data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="bit_depth">bit_depth</dfn> indicates the bit depth of pixel components within the output samples from the AV1 bitstream. The value MUST be 8, 10, or 12.</p>
+    <li data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="monochrome">monochrome</dfn> indicates the value of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⓪">mono_chrome</a> flag from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⓪">Sequence Header OBU</a>.</p>
    </ul>
-   <p>When smooth presentation can be guaranteed after decoding the first sample, the value 0 SHALL be used. If an ISOBMFF writer cannot verify the above procedure, <a data-link-type="dfn" href="#initial_presentation_delay_present" id="ref-for-initial_presentation_delay_present">initial_presentation_delay_present</a> SHALL be set to 0.</p>
-   <p>The presentation times of AV1 samples are given by the ISOBMFF structures. The <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①③">timing_info_present_flag</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41④">Sequence Header OBU</a> (in the configOBUs field or in the associated samples) SHOULD be set to 0. If set to 1, the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=45" id="ref-for-page=45">timing_info</a> structure of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑤">Sequence Header OBU</a>, the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①④">frame_presentation_time</a> and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑤">buffer_removal_time</a> fields of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49">Frame Header OBUs</a>, if present, SHALL be ignored for the purpose of timed processing of the ISOBMFF file.</p>
-   <p>If a <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-③">colr</a> box is present in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④">VisualSampleEntry</a> with a colour_type set to <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑤">nclx</a>, the values of colour_primaries, transfer_characteristics, and matrix_coefficients SHALL match the values given in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑥">Sequence Header OBU</a> (in the configOBUs field or in the associated samples) if the color_description_present_flag is set to 1. Similarly, the full_range_flag in the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑥">colr</a> box shall match the color_range flag in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑦">Sequence Header OBU</a>.</p>
+   <p>The presentation times of AV1 samples are given by the ISOBMFF structures. The <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①①">timing_info_present_flag</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①①">Sequence Header OBU</a> (in the configOBUs field or in the associated samples) SHOULD be set to 0. If set to 1, the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=45" id="ref-for-page=45">timing_info</a> structure of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①②">Sequence Header OBU</a>, the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①②">frame_presentation_time</a> and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①③">buffer_removal_time</a> fields of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49">Frame Header OBUs</a>, if present, SHALL be ignored for the purpose of timed processing of the ISOBMFF file.</p>
+   <p>If a <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-③">colr</a> box is present in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④">VisualSampleEntry</a> with a colour_type set to <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑤">nclx</a>, the values of colour_primaries, transfer_characteristics, and matrix_coefficients SHALL match the values given in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①③">Sequence Header OBU</a> (in the configOBUs field or in the associated samples) if the color_description_present_flag is set to 1. Similarly, the full_range_flag in the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑥">colr</a> box shall match the color_range flag in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①④">Sequence Header OBU</a>.</p>
    <p>Additional boxes may be provided at the end of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-⑦">VisualSampleEntry</a> as permitted by ISOBMFF, that may represent redundant or similar information to the one provided in some OBUs contained in the <a data-link-type="dfn" href="#av1codecconfigurationbox" id="ref-for-av1codecconfigurationbox⑤">AV1CodecConfigurationBox</a>. If the box definition does not indicate that its information overrides the OBU information, in case of conflict, the OBU information should be considered authoritative.</p>
    <h3 class="heading settled" data-level="2.5" id="sampleformat"><span class="secno">2.5. </span><span class="content">AV1 Sample Format</span><a class="self-link" href="#sampleformat"></a></h3>
    <p>For tracks using the <a data-link-type="dfn" href="#av1sampleentry" id="ref-for-av1sampleentry②">AV1SampleEntry</a>, an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1-sample">AV1 Sample</dfn> has the following constraints:</p>
@@ -1610,9 +1616,9 @@ aligned (8) class AV1CodecConfigurationRecord {
     <li data-md="">
      <p>the sample data SHALL be a sequence of <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39②">OBUs</a> forming a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑤">Temporal Unit</a>,</p>
     <li data-md="">
-     <p>each OBU SHALL follow the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑥">open_bitstream_unit</a> <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39③">Low Overhead Bitstream Format</a> syntax as specified in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>. Each OBU SHALL have the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑦">obu_has_size_field</a> set to 1 except for the last OBU in the sample, for which <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑧">obu_has_size_field</a> MAY be set to 0, in which case it is assumed to fill the remainder of the sample,</p>
+     <p>each OBU SHALL follow the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①④">open_bitstream_unit</a> <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39③">Low Overhead Bitstream Format</a> syntax as specified in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>. Each OBU SHALL have the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑤">obu_has_size_field</a> set to 1 except for the last OBU in the sample, for which <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑥">obu_has_size_field</a> MAY be set to 0, in which case it is assumed to fill the remainder of the sample,</p>
    </ul>
-   <p class="note" role="note"><span>NOTE:</span> When extracting OBUs from an ISOBMFF file, and depending on the capabilities of the decoder processing these OBUs, ISOBMFF parsers MAY need to either: set the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑨">obu_has_size_field</a> to 1 for some OBUs if not already set, add the size field in this case, and add <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46">Temporal Delimiter OBU</a>; or use the length-delimited bitstream format as defined in Annex B of <a data-link-type="dfn" href="#av1s" id="ref-for-av1s">AV1</a>. If encryption is used, similar operations MAY have to be done before or after decryption depending on the demuxer/decryptor/decoder architecture.</p>
+   <p class="note" role="note"><span>NOTE:</span> When extracting OBUs from an ISOBMFF file, and depending on the capabilities of the decoder processing these OBUs, ISOBMFF parsers MAY need to either: set the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑦">obu_has_size_field</a> to 1 for some OBUs if not already set, add the size field in this case, and add <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46">Temporal Delimiter OBU</a>; or use the length-delimited bitstream format as defined in Annex B of <a data-link-type="dfn" href="#av1s" id="ref-for-av1s">AV1</a>. If encryption is used, similar operations MAY have to be done before or after decryption depending on the demuxer/decryptor/decoder architecture.</p>
    <ul>
     <li data-md="">
      <p>OBU trailing bits SHOULD be limited to byte alignment and SHOULD not be used for padding,</p>
@@ -1622,12 +1628,12 @@ aligned (8) class AV1CodecConfigurationRecord {
    <p>If an AV1 Sample is signaled as a sync sample (in the SyncSampleBox or by setting sample_is_non_sync_sample to 0), it SHALL be a Random Access Point as defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>, i.e. satisfy the following constraints:</p>
    <ul>
     <li data-md="">
-     <p>Its first frame is a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑥">Key Frame</a> that has <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⓪">show_frame</a> flag set to 1,</p>
+     <p>Its first frame is a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑥">Key Frame</a> that has <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑧">show_frame</a> flag set to 1,</p>
     <li data-md="">
-     <p>It contains a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑧">Sequence Header OBU</a> before the first <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49①">Frame Header OBU</a>.</p>
+     <p>It contains a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑤">Sequence Header OBU</a> before the first <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49①">Frame Header OBU</a>.</p>
    </ul>
    <p class="note" role="note"><span>NOTE:</span> Within this definition, a sync sample may contain additional frames that are not Key Frames. The fact that none of them is the first frame in the temporal unit ensures that they are decodable.</p>
-   <p class="note" role="note"><span>NOTE:</span> Other types of OBUs such as <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47①">metadata OBUs</a> could be present before the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑨">Sequence Header OBU</a>.</p>
+   <p class="note" role="note"><span>NOTE:</span> Other types of OBUs such as <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47①">metadata OBUs</a> could be present before the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑥">Sequence Header OBU</a>.</p>
    <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑦">Intra-only frames</a> SHOULD be signaled using the sample_depends_on flag set to 2.</p>
    <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑦">Delayed Random Access Points</a> SHOULD be signaled using sample groups and the <a data-link-type="dfn" href="#av1forwardkeyframesamplegroupentry" id="ref-for-av1forwardkeyframesamplegroupentry①">AV1ForwardKeyFrameSampleGroupEntry</a>.</p>
    <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑧">Switch Frames</a> SHOULD be signaled using sample groups and the <a data-link-type="dfn" href="#av1switchframesamplegroupentry" id="ref-for-av1switchframesamplegroupentry">AV1SwitchFrameSampleGroupEntry</a>.</p>
@@ -1767,8 +1773,8 @@ Quantity:   Zero or more.
    <p>When the protected scheme <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①③">cenc</a></code> or <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①④">cbc1</a></code> is used, samples SHALL be protected using subsample encryption and SHALL NOT use pattern encryption.</p>
    <p>When the protected scheme <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑤">cens</a></code> or <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑥">cbcs</a></code> is used, samples SHALL be protected using subsample encryption and SHALL use pattern encryption.</p>
    <h3 class="heading settled" data-level="4.1" id="subsample-encryption"><span class="secno">4.1. </span><span class="content">General Subsample Encryption constraints</span><a class="self-link" href="#subsample-encryption"></a></h3>
-   <p>Within protected samples, the following constraints apply:</p>
-   <ul>
+   <p>When encrypting <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39④">OBUs</a>, all <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40">OBU Headers</a> and associated <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②①">obu_size</a> fields SHALL be unencrypted. Additionally, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46">Temporal Delimiter OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⓪">Sequence Header OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47⑥">Metadata OBUs</a> (except for those requiring protection), <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49②">Frame Header OBUs</a> SHALL be unencrypted.</p>
+   <p>Within encrypted samples, all <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40①">OBU Headers</a> and associated <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②②">obu_size</a> fields SHALL be unencrypted. Additionally, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46①">Temporal Delimiter OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①①">Sequence Header OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47⑦">Metadata OBUs</a> (except for those requiring protection), <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49③">Frame Header OBUs</a> (including with a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71">Frame OBU</a>) SHALL be unencrypted. <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=72" id="ref-for-page=72">Tile Group OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71①">Frame OBUs</a> (except the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49④">Frame Header OBU</a> part) and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=121" id="ref-for-page=121">Tile List OBUs</a> MAY be encrypted. This is illustrated in Figure #1 and Figure #2, where for simplicity the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②③">obu_size</a> field is assumed to be part of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40②">OBU Header</a>.</p>
     <li data-md="">
      <p>Protected samples SHALL be exactly spanned by one or more contiguous subsamples.</p>
     <li data-md="">
@@ -1792,7 +1798,7 @@ Quantity:   Zero or more.
    </ul>
    <h3 class="heading settled" data-level="4.2" id="ctr-subsample-encryption"><span class="secno">4.2. </span><span class="content">Subsample encryption using AES-CTR</span><a class="self-link" href="#ctr-subsample-encryption"></a></h3>
     For AES-CTR based scheme types, such as <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-②①">cenc</a></code>, the encrypted bytes of each OBU within the sample SHALL be block-aligned so that the counter state can be computed for each OBU within the sample. Block alignment is achieved by adjusting the size of the unencrypted bytes that precede the encrypted bytes for that OBU. In other words, partial blocks are not permitted. 
-   <h3 class="heading settled" data-level="4.3" id="cbc-subsample-encryption"><span class="secno">4.3. </span><span class="content">Subsample encryption using AES-CBC</span><a class="self-link" href="#cbc-subsample-encryption"></a></h3>
+   <p>For AES-CBC based scheme types, such as <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑦">cbcs</a></code>, <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑧">BytesOfProtectedData</a> SHALL start on the first complete byte of OBU data that is permitted to be encrypted (i.e. after the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40③">OBU Header</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②④">obu_size</a>, possible <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49⑤">Frame Header OBU</a> and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⑤">byte_alignment</a>), and end on the end of the last complete 16-byte block of data in the OBU. Partial blocks at the end of OBUs, if any, SHALL be left unencrypted as specified in <a data-link-type="biblio" href="#biblio-cenc">[CENC]</a>.</p>
     For AES-CBC based scheme types, such as <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-②②">cbcs</a></code>, <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-②③">BytesOfProtectedData</a> SHALL start on the first complete byte of OBU data that is permitted to be protected, and end on the end of the last complete 16-byte block of data in the OBU. In other words, partial blocks at the end of OBUs, if any, SHALL be left unprotected. 
    <h3 class="heading settled" data-level="4.4" id="subsample-encryption-illustration"><span class="secno">4.4. </span><span class="content">Illustration</span><a class="self-link" href="#subsample-encryption-illustration"></a></h3>
    <p>This is illustrated in Figure #1 and Figure #2, where for simplicity the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②②">obu_size</a> field is assumed to be part of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40①">OBU Header</a>.</p>
@@ -1810,13 +1816,13 @@ Quantity:   Zero or more.
 &lt;colorPrimaries>.&lt;transferCharacteristics>.&lt;matrixCoefficients>.&lt;videoFullRangeFlag>
 </pre>
    <p>All fields following the sample entry 4CC are expressed as double digit decimals, unless indicated otherwise. Leading or trailing zeros cannot be omitted.</p>
-   <p>The profile parameter value, represented by a single digit decimal, SHALL equal the value of seq_profile in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①①">Sequence Header OBU</a>.</p>
-   <p>The level parameter value SHALL equal the first level value indicated by <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②③">seq_level_idx</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①②">Sequence Header OBU</a>.</p>
-   <p>The tier parameter value SHALL be equal to <code>M</code> when the first <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②④">seq_tier</a> value in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①③">Sequence Header OBU</a> is equal to 0, and <code>H</code> when it is equal to 1.</p>
-   <p>The bitDepth parameter value SHALL equal the value of BitDepth variable as defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> derived from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①④">Sequence Header OBU</a>.</p>
-   <p>The monochrome parameter value, represented by a single digit decimal, SHALL equal the value of mono_chrome in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑤">Sequence Header OBU</a>.</p>
+   <p>The profile parameter value, represented by a single digit decimal, SHALL equal the value of seq_profile in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①②">Sequence Header OBU</a>.</p>
+   <p>The level parameter value SHALL equal the first level value indicated by <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⑥">seq_level_idx</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①③">Sequence Header OBU</a>.</p>
+   <p>The tier parameter value SHALL be equal to <code>M</code> when the first <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⑦">seq_tier</a> value in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①④">Sequence Header OBU</a> is equal to 0, and <code>H</code> when it is equal to 1.</p>
+   <p>The bitDepth parameter value SHALL equal the value of BitDepth variable as defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> derived from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑤">Sequence Header OBU</a>.</p>
+   <p>The monochrome parameter value, represented by a single digit decimal, SHALL equal the value of mono_chrome in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑥">Sequence Header OBU</a>.</p>
    <p>The chromaSubsampling parameter value, represented by a three-digit decimal, SHALL have its first digit equal to subsampling_x and its second digit equal to subsampling_y. If both subsampling_x and subsampling_y are set to 1, then the third digit SHALL be equal to chroma_sample_position, otherwise it SHALL be set to 0.</p>
-   <p>The colorPrimaries, transferCharacteristics, matrixCoefficients and videoFullRangeFlag parameter values SHALL equal the value of matching fields in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑥">Sequence Header OBU</a>, if color_description_present_flag is set to 1, otherwise they SHOULD not be set, defaulting to the values below. The videoFullRangeFlag is represented by a single digit.</p>
+   <p>The colorPrimaries, transferCharacteristics, matrixCoefficients and videoFullRangeFlag parameter values SHALL equal the value of matching fields in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑦">Sequence Header OBU</a>, if color_description_present_flag is set to 1, otherwise they SHOULD not be set, defaulting to the values below. The videoFullRangeFlag is represented by a single digit.</p>
    <p>For example, codecs="av01.0.04M.10.0.112.09.16.09.0" represents AV1 profile 0, level 3.0, Main tier, 10-bit content, non-monochrome, with 4:2:0 chroma subsampling, ITU-R BT.2100 color primaries, ITU BT.2100 PQ transfer characteristics, ITU-R BT.2100 YCbCr color matrix, and studio swing representation.</p>
    <p>The parameters sample entry 4CC, profile, level, tier, and bitDepth are all mandatory fields. If any of these fields are empty, or not within their allowed range, the processing device SHOULD treat it as an error.</p>
    <p>All the other fields (including their leading '.') are optional, mutually inclusive (all or none) fields. If not specified then the values listed in the table below are assumed.</p>
@@ -2011,15 +2017,20 @@ Quantity:   Zero or more.
    <li><a href="#av1-sample">AV1 Sample</a><span>, in §2.5</span>
    <li><a href="#av1sampleentry">AV1SampleEntry</a><span>, in §2.3.2</span>
    <li><a href="#av1switchframesamplegroupentry">AV1SwitchFrameSampleGroupEntry</a><span>, in §2.8.2</span>
+   <li><a href="#bit_depth">bit_depth</a><span>, in §2.4.4</span>
    <li><a href="#cmaf-av1-track">CMAF AV1 Track</a><span>, in §3</span>
    <li><a href="#compressorname">compressorname</a><span>, in §2.3.4</span>
    <li><a href="#config">config</a><span>, in §2.3.4</span>
    <li><a href="#configobus">configOBUs</a><span>, in §2.4.4</span>
    <li><a href="#fwd_distance">fwd_distance</a><span>, in §2.6.4</span>
    <li><a href="#height">height</a><span>, in §2.3.4</span>
-   <li><a href="#initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</a><span>, in §2.4.4</span>
-   <li><a href="#initial_presentation_delay_present">initial_presentation_delay_present</a><span>, in §2.4.4</span>
    <li><a href="#metadata_type">metadata_type</a><span>, in §2.9.4</span>
+   <li><a href="#monochrome">monochrome</a><span>, in §2.4.4</span>
+   <li><a href="#seq_level_idx_0">seq_level_idx_0</a><span>, in §2.4.4</span>
+   <li><a href="#seq_profile">seq_profile</a><span>, in §2.4.4</span>
+   <li><a href="#seq_tier_0">seq_tier_0</a><span>, in §2.4.4</span>
+   <li><a href="#sequence_parameters_present">sequence_parameters_present</a><span>, in §2.4.4</span>
+   <li><a href="#still_picture">still_picture</a><span>, in §2.4.4</span>
    <li><a href="#width">width</a><span>, in §2.3.4</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-page=1">
@@ -2034,11 +2045,15 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
+    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
+    <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
+    <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
     <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
     <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. General Subsample Encryption constraints</a>
-    <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
-    <li><a href="#ref-for-page=2②③">5. Codecs Parameter String</a> <a href="#ref-for-page=2②④">(2)</a>
+    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
+    <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=206">
@@ -2069,23 +2084,14 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
+    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
-    <li><a href="#ref-for-page=2②③">5. Codecs Parameter String</a> <a href="#ref-for-page=2②④">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-page=2">
-   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
-    <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
+    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
-    <li><a href="#ref-for-page=2②③">5. Codecs Parameter String</a> <a href="#ref-for-page=2②④">(2)</a>
+    <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=13">
@@ -2134,11 +2140,11 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
+    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
-    <li><a href="#ref-for-page=2②③">5. Codecs Parameter String</a> <a href="#ref-for-page=2②④">(2)</a>
+    <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
@@ -2146,11 +2152,11 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
+    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
-    <li><a href="#ref-for-page=2②③">5. Codecs Parameter String</a> <a href="#ref-for-page=2②④">(2)</a>
+    <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=47">
@@ -2161,6 +2167,17 @@ Quantity:   Zero or more.
     <li><a href="#ref-for-page=47④">2.9.2. Description</a>
     <li><a href="#ref-for-page=47⑤">3. CMAF AV1 track format and CMAF media profiles</a>
     <li><a href="#ref-for-page=47⑥">4.1. General Subsample Encryption constraints</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-page=2">
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
+    <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
+    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2①⑨">4.1. Sample Encryption</a> <a href="#ref-for-page=2②⓪">(2)</a> <a href="#ref-for-page=2②①">(3)</a> <a href="#ref-for-page=2②②">(4)</a> <a href="#ref-for-page=2②③">(5)</a>
+    <li><a href="#ref-for-page=2②④">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=39">
@@ -2183,11 +2200,11 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
+    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
-    <li><a href="#ref-for-page=2②③">5. Codecs Parameter String</a> <a href="#ref-for-page=2②④">(2)</a>
+    <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
@@ -2195,11 +2212,11 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
+    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
-    <li><a href="#ref-for-page=2②③">5. Codecs Parameter String</a> <a href="#ref-for-page=2②④">(2)</a>
+    <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
@@ -2207,11 +2224,11 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
+    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
-    <li><a href="#ref-for-page=2②③">5. Codecs Parameter String</a> <a href="#ref-for-page=2②④">(2)</a>
+    <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=206">
@@ -2228,11 +2245,11 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
+    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
-    <li><a href="#ref-for-page=2②③">5. Codecs Parameter String</a> <a href="#ref-for-page=2②④">(2)</a>
+    <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
@@ -2240,21 +2257,21 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
+    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
-    <li><a href="#ref-for-page=2②③">5. Codecs Parameter String</a> <a href="#ref-for-page=2②④">(2)</a>
+    <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=41">
    <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=41">2.3.4. Semantics</a> <a href="#ref-for-page=41①">(2)</a>
-    <li><a href="#ref-for-page=41②">2.4.4. Semantics</a> <a href="#ref-for-page=41③">(2)</a> <a href="#ref-for-page=41④">(3)</a> <a href="#ref-for-page=41⑤">(4)</a> <a href="#ref-for-page=41⑥">(5)</a> <a href="#ref-for-page=41⑦">(6)</a>
-    <li><a href="#ref-for-page=41⑧">2.5. AV1 Sample Format</a> <a href="#ref-for-page=41⑨">(2)</a>
-    <li><a href="#ref-for-page=41①⓪">4.1. General Subsample Encryption constraints</a>
-    <li><a href="#ref-for-page=41①①">5. Codecs Parameter String</a> <a href="#ref-for-page=41①②">(2)</a> <a href="#ref-for-page=41①③">(3)</a> <a href="#ref-for-page=41①④">(4)</a> <a href="#ref-for-page=41①⑤">(5)</a> <a href="#ref-for-page=41①⑥">(6)</a>
+    <li><a href="#ref-for-page=41②">2.4.4. Semantics</a> <a href="#ref-for-page=41③">(2)</a> <a href="#ref-for-page=41④">(3)</a> <a href="#ref-for-page=41⑤">(4)</a> <a href="#ref-for-page=41⑥">(5)</a> <a href="#ref-for-page=41⑦">(6)</a> <a href="#ref-for-page=41⑧">(7)</a> <a href="#ref-for-page=41⑨">(8)</a> <a href="#ref-for-page=41①⓪">(9)</a> <a href="#ref-for-page=41①①">(10)</a> <a href="#ref-for-page=41①②">(11)</a> <a href="#ref-for-page=41①③">(12)</a> <a href="#ref-for-page=41①④">(13)</a>
+    <li><a href="#ref-for-page=41①⑤">2.5. AV1 Sample Format</a> <a href="#ref-for-page=41①⑥">(2)</a>
+    <li><a href="#ref-for-page=41①⓪">4.1. Sample Encryption</a> <a href="#ref-for-page=41①①">(2)</a>
+    <li><a href="#ref-for-page=41①②">5. Codecs Parameter String</a> <a href="#ref-for-page=41①③">(2)</a> <a href="#ref-for-page=41①④">(3)</a> <a href="#ref-for-page=41①⑤">(4)</a> <a href="#ref-for-page=41①⑥">(5)</a> <a href="#ref-for-page=41①⑦">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
@@ -2262,11 +2279,11 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
+    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
-    <li><a href="#ref-for-page=2②③">5. Codecs Parameter String</a> <a href="#ref-for-page=2②④">(2)</a>
+    <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
@@ -2274,11 +2291,11 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
+    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
-    <li><a href="#ref-for-page=2②③">5. Codecs Parameter String</a> <a href="#ref-for-page=2②④">(2)</a>
+    <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=13">
@@ -2327,11 +2344,11 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
+    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
-    <li><a href="#ref-for-page=2②③">5. Codecs Parameter String</a> <a href="#ref-for-page=2②④">(2)</a>
+    <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
@@ -2541,7 +2558,7 @@ Quantity:   Zero or more.
      <li><span class="dfn-paneled" id="term-for-page=49" style="color:initial">frame header obu</span>
      <li><span class="dfn-paneled" id="term-for-page=71" style="color:initial">frame obu</span>
      <li><span class="dfn-paneled" id="term-for-page=2①" style="color:initial">frame_presentation_time</span>
-     <li><span class="dfn-paneled" id="term-for-page=2②" style="color:initial">initial_display_delay_minus_1</span>
+     <li><span class="dfn-paneled" id="term-for-page=2③" style="color:initial">initial_display_delay_minus_1</span>
      <li><span class="dfn-paneled" id="term-for-page=13" style="color:initial">inter frame</span>
      <li><span class="dfn-paneled" id="term-for-page=13①" style="color:initial">intra-only frame</span>
      <li><span class="dfn-paneled" id="term-for-page=13②" style="color:initial">key frame</span>
@@ -2550,6 +2567,7 @@ Quantity:   Zero or more.
      <li><span class="dfn-paneled" id="term-for-page=2③" style="color:initial">max_frame_height_minus_1</span>
      <li><span class="dfn-paneled" id="term-for-page=2④" style="color:initial">max_frame_width_minus_1</span>
      <li><span class="dfn-paneled" id="term-for-page=47" style="color:initial">metadata obu</span>
+     <li><span class="dfn-paneled" id="term-for-page=2⑤" style="color:initial">mono_chrome</span>
      <li><span class="dfn-paneled" id="term-for-page=39①" style="color:initial">obu</span>
      <li><span class="dfn-paneled" id="term-for-page=40" style="color:initial">obu header</span>
      <li><span class="dfn-paneled" id="term-for-page=2⑤" style="color:initial">obu_has_size_field</span>
@@ -2604,7 +2622,7 @@ Quantity:   Zero or more.
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-av1">[AV1]
-   <dd><a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf">AV1 Bitstream &amp; Decoding Process Specification</a>. LS. URL: <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf">http://aomediacodec.github.io/av1-spec/av1-spec.pdf</a>
+   <dd><a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf">AV1 Bitstream &amp; Decoding Process Specification</a>. Standard. URL: <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf">http://aomediacodec.github.io/av1-spec/av1-spec.pdf</a>
    <dt id="biblio-cenc">[CENC]
    <dd><a href="https://www.iso.org/standard/68042.html">Information technology — MPEG systems technologies — Part 7: Common encryption in ISO base media file format files</a>. Standard. URL: <a href="https://www.iso.org/standard/68042.html">https://www.iso.org/standard/68042.html</a>
    <dt id="biblio-cmaf">[CMAF]
@@ -2633,16 +2651,40 @@ Quantity:   Zero or more.
     <li><a href="#ref-for-av1codecconfigurationbox③">2.4.4. Semantics</a> <a href="#ref-for-av1codecconfigurationbox④">(2)</a> <a href="#ref-for-av1codecconfigurationbox⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initial_presentation_delay_present">
-   <b><a href="#initial_presentation_delay_present">#initial_presentation_delay_present</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="seq_profile">
+   <b><a href="#seq_profile">#seq_profile</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-initial_presentation_delay_present">2.4.4. Semantics</a>
+    <li><a href="#ref-for-seq_profile">2.4.4. Semantics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initial_presentation_delay_minus_one">
-   <b><a href="#initial_presentation_delay_minus_one">#initial_presentation_delay_minus_one</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="still_picture">
+   <b><a href="#still_picture">#still_picture</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-initial_presentation_delay_minus_one">2.4.4. Semantics</a>
+    <li><a href="#ref-for-still_picture">2.4.4. Semantics</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="seq_level_idx_0">
+   <b><a href="#seq_level_idx_0">#seq_level_idx_0</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-seq_level_idx_0">2.4.4. Semantics</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="seq_tier_0">
+   <b><a href="#seq_tier_0">#seq_tier_0</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-seq_tier_0">2.4.4. Semantics</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="bit_depth">
+   <b><a href="#bit_depth">#bit_depth</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-bit_depth">2.4.4. Semantics</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="monochrome">
+   <b><a href="#monochrome">#monochrome</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-monochrome">2.4.4. Semantics</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="av1-sample">

--- a/index.html
+++ b/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 0e8880531a1904b4bc0b037759fa3cb386293992" name="generator">
   <link href="https://AOMediaCodec.github.io/av1-isobmff" rel="canonical">
-  <meta content="f9d6560d5e6d71fb33e9c593f885109377b7c8c4" name="document-revision">
+  <meta content="8c656f30fe9a126377ffc4bae5a20df34c882fcc" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1402,7 +1402,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">AV1 Codec ISO Media File Format Binding</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2018-08-07">7 August 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2018-08-09">9 August 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1569,6 +1569,7 @@ Quantity:  Exactly One
 
 aligned (8) class AV1CodecConfigurationRecordv1 {
   unsigned int (4) reserved = 0;
+  unsigned int (3) version;
   unsigned int (1) initial_presentation_delay_present;
   if (initial_presentation_delay_present) {
     unsigned int (4) initial_presentation_delay_minus_one;
@@ -1582,14 +1583,54 @@ aligned (8) class AV1CodecConfigurationRecordv1 {
     unsigned int (5) seq_level_idx_0;
     unsigned int (1) seq_tier_0;
     unsigned int (4) bit_depth;
+    unsigned int (1) monochrome;
+    unsigned int (1) chroma_subsampling_x;
+    unsigned int (1) chroma_subsampling_y;
+    unsigned int (2) chroma_sample_position;
   } else {
-    unsigned int (14) reserved = 0;
+    unsigned int (19) reserved = 0;
   }
   unsigned int (8)[] configOBUs;
 }
 </pre>
    <h4 class="heading settled" data-level="2.4.4" id="av1codecconfigurationbox-semantics"><span class="secno">2.4.4. </span><span class="content">Semantics</span><a class="self-link" href="#av1codecconfigurationbox-semantics"></a></h4>
-   <p>Previous versions of this specification defined AV1CodecConfigurationRecord. Use of AV1CodecConfigurationRecord is deprecated.</p>
+   <p>Previous versions of this specification defined v0 of the AV1CodecConfigurationRecord. Use of AV1CodecConfigurationRecord v0 is deprecated.</p>
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="version">version<a class="self-link" href="#version"></a></dfn> field indicates the version of the AV1CodecConfigurationRecordv1. The value SHALL be set to 1 for AV1CodecConfigurationRecordv1.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="initial_presentation_delay_present">initial_presentation_delay_present</dfn> field indicates the presence of the initial_presentation_delay_minus_one field.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</dfn> field indicates the number of samples (minus one) that need be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑧">seq_level_idx</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②">Sequence Header OBU</a> (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:</p>
+   <ul>
+    <li data-md="">
+     <p>construct a hypothetical bitstream consisting of the OBUs carried in the sample entry followed by the OBUs carried in all the samples,</p>
+    <li data-md="">
+     <p>set the first <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑨">initial_display_delay_minus_1</a> field of each <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41③">Sequence Header OBU</a> to the number of frames contained in the first <a data-link-type="dfn" href="#initial_presentation_delay_minus_one" id="ref-for-initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</a> + 1 samples,</p>
+    <li data-md="">
+     <p>set the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⓪">frame_presentation_time</a> field of the frame header of each presentable frame such that it matches the presentation time difference between the sample carrying this frame and the previous sample (if it exists, 0 otherwise),</p>
+    <li data-md="">
+     <p>apply the display model verification algorithm.</p>
+   </ul>
+   <p>When smooth presentation can be guaranteed after decoding the first sample, the value 0 SHALL be used. If an ISOBMFF writer cannot verify the above procedure, <a data-link-type="dfn" href="#initial_presentation_delay_present" id="ref-for-initial_presentation_delay_present">initial_presentation_delay_present</a> SHALL be set to 0.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="sequence_parameters_present">sequence_parameters_present</dfn> field indicates the presence of the parameters <a data-link-type="dfn" href="#seq_profile" id="ref-for-seq_profile">seq_profile</a>, <a data-link-type="dfn" href="#still_picture" id="ref-for-still_picture">still_picture</a>, <a data-link-type="dfn" href="#seq_level_idx_0" id="ref-for-seq_level_idx_0">seq_level_idx_0</a>, <a data-link-type="dfn" href="#seq_tier_0" id="ref-for-seq_tier_0">seq_tier_0</a>, and <a data-link-type="dfn" href="#bit_depth" id="ref-for-bit_depth">bit_depth</a> fields from the AV1 <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41④">Sequence Header OBU</a>.</p>
+   <ul>
+    <li data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="seq_profile">seq_profile</dfn> indicates the AV1 profile and SHALL be equal to the seq_profile value from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑤">Sequence Header OBU</a>.</p>
+    <li data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="still_picture">still_picture</dfn> indicates the value of the still_picture field found in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑥">Sequence Header OBU</a> and SHALL be equal to the value from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑦">Sequence Header OBU</a>.</p>
+    <li data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="seq_level_idx_0">seq_level_idx_0</dfn> indicates the value of seq_level_idx[0] found in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑧">Sequence Header OBU</a> and SHALL be equal to the value of seq_level_idx[0] in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑨">Sequence Header OBU</a>.</p>
+    <li data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="seq_tier_0">seq_tier_0</dfn> indicates the value of seq_tier[0] found in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⓪">Sequence Header OBU</a> and SHALL be equal to the value of seq_tier[0] in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①①">Sequence Header OBU</a>.</p>
+    <li data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="bit_depth">bit_depth</dfn> indicates the bit depth of pixel components within the output samples from the AV1 bitstream. The value MUST be 8, 10, or 12.</p>
+    <li data-md="">
+     <p><dfn data-dfn-type="dfn" data-export="" id="monochrome">monochrome<a class="self-link" href="#monochrome"></a></dfn> indicates the value of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①①">mono_chrome</a> flag from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①②">Sequence Header OBU</a>.</p>
+    <li data-md="">
+     <p><dfn data-dfn-type="dfn" data-export="" id="chroma_subsampling_x">chroma_subsampling_x<a class="self-link" href="#chroma_subsampling_x"></a></dfn> indicates the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①②">subsampling_x</a> value from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①③">Sequence Header OBU</a>.</p>
+    <li data-md="">
+     <p><dfn data-dfn-type="dfn" data-export="" id="chroma_subsampling_y">chroma_subsampling_y<a class="self-link" href="#chroma_subsampling_y"></a></dfn> indicates the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①③">subsampling_y</a> value from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①④">Sequence Header OBU</a>.</p>
+    <li data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="chroma_sample_position">chroma_sample_position</dfn> indicates the <a data-link-type="dfn" href="#chroma_sample_position" id="ref-for-chroma_sample_position">chroma_sample_position</a> value from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑤">Sequence Header OBU</a>.</p>
+   </ul>
+   <p>When the AV1CodecConfigurationRecordv1 indicates that fields from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑥">Sequence Header OBU</a> are present via <a data-link-type="dfn" href="#sequence_parameters_present" id="ref-for-sequence_parameters_present">sequence_parameters_present</a>, and a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑦">Sequence Header OBU</a> is present within the configOBUs, the values present in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑧">Sequence Header OBU</a> contained within configOBUs SHALL match the values of the AV1CodecConfigurationRecordv1 sequence parameters.</p>
    <p>The <dfn data-dfn-type="dfn" data-export="" id="configobus">configOBUs<a class="self-link" href="#configobus"></a></dfn> field contains zero or more OBUs. Any OBU may be present provided that the following procedures produce compliant AV1 bitstreams:</p>
    <ul>
     <li data-md="">
@@ -1598,46 +1639,20 @@ aligned (8) class AV1CodecConfigurationRecordv1 {
      <p>From any sample marked with the <a data-link-type="dfn" href="#av1forwardkeyframesamplegroupentry" id="ref-for-av1forwardkeyframesamplegroupentry">AV1ForwardKeyFrameSampleGroupEntry</a>, an AV1 bitstream is formed by first outputting the OBUs contained in the <a data-link-type="dfn" href="#av1codecconfigurationbox" id="ref-for-av1codecconfigurationbox④">AV1CodecConfigurationBox</a> and then by outputing all OBUs in the sample itself, then by outputting all OBUs in the samples, in order, starting from the sample at the distance indicated by the sample group.</p>
    </ul>
    <p class="note" role="note"><span>NOTE:</span> The configOBUs field is expected to contain only OBU_SEQUENCE_HEADER and OBU_METADATA when the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47">metadata OBU</a> is applicable to all the associated samples.</p>
-   <p>OBUs stored in the configOBUs field follow the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑧">open_bitstream_unit</a> <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39①">Low Overhead Bitstream Format</a> syntax as specified in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>. The flag <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑨">obu_has_size_field</a> SHALL be set to 1, indicating that the size of the OBU payload follows the header, and that it is coded using LEB128.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="initial_presentation_delay_present">initial_presentation_delay_present</dfn> field indicates the presence of the initial_presentation_delay_minus_one field.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</dfn> field indicates the number of samples (minus one) that need be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⓪">seq_level_idx</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②">Sequence Header OBU</a> (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:</p>
-   <ul>
-    <li data-md="">
-     <p>construct a hypothetical bitstream consisting of the OBUs carried in the sample entry followed by the OBUs carried in all the samples,</p>
-    <li data-md="">
-     <p>set the first <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①①">initial_display_delay_minus_1</a> field of each <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41③">Sequence Header OBU</a> to the number of frames contained in the first <a data-link-type="dfn" href="#initial_presentation_delay_minus_one" id="ref-for-initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</a> + 1 samples,</p>
-    <li data-md="">
-     <p>set the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①②">frame_presentation_time</a> field of the frame header of each presentable frame such that it matches the presentation time difference between the sample carrying this frame and the previous sample (if it exists, 0 otherwise),</p>
-    <li data-md="">
-     <p>apply the display model verification algorithm.</p>
-   </ul>
-   <p>When smooth presentation can be guaranteed after decoding the first sample, the value 0 SHALL be used. If an ISOBMFF writer cannot verify the above procedure, <a data-link-type="dfn" href="#initial_presentation_delay_present" id="ref-for-initial_presentation_delay_present">initial_presentation_delay_present</a> SHALL be set to 0.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="sequence_parameters_present">sequence_parameters_present</dfn> field indicates the presence of the parameters <a data-link-type="dfn" href="#seq_profile" id="ref-for-seq_profile">seq_profile</a>, <a data-link-type="dfn" href="#still_picture" id="ref-for-still_picture">still_picture</a>, <a data-link-type="dfn" href="#seq_level_idx_0" id="ref-for-seq_level_idx_0">seq_level_idx_0</a>, <a data-link-type="dfn" href="#seq_tier_0" id="ref-for-seq_tier_0">seq_tier_0</a>, and <a data-link-type="dfn" href="#bit_depth" id="ref-for-bit_depth">bit_depth</a> fields from the AV1 <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41④">Sequence Header OBU</a>.</p>
-   <ul>
-    <li data-md="">
-     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="seq_profile">seq_profile</dfn> indicates the AV1 profile and SHALL be equal to the seq_profile value from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑤">Sequence Header OBU</a>.</p>
-    <li data-md="">
-     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="still_picture">still_picture</dfn> indicates the value of the still_picture field found in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑥">Sequence Header OBU</a> and SHALL be equal to the value from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑦">Sequence Header OBU</a>.</p>
-    <li data-md="">
-     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="seq_level_idx_0">seq_level_idx_0</dfn> indicates the value of seq_level_idx[0] found in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑧">Sequence Header OBU</a> and SHALL be equal to the value of seq_level_idx[0] in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑨">Sequence Header OBU</a>.</p>
-    <li data-md="">
-     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="seq_tier_0">seq_tier_0</dfn> indicates the value of seq_tier[0] found in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⓪">Sequence Header OBU</a> and SHALL be equal to the value of seq_tier[0] in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①①">Sequence Header OBU</a>.</p>
-    <li data-md="">
-     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="bit_depth">bit_depth</dfn> indicates the bit depth of pixel components within the output samples from the AV1 bitstream. The value MUST be 8, 10, or 12.</p>
-   </ul>
-   <p>When the AV1CodecConfigurationRecordv1 indicates that fields from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①②">Sequence Header OBU</a> are present via <a data-link-type="dfn" href="#sequence_parameters_present" id="ref-for-sequence_parameters_present">sequence_parameters_present</a>, and a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①③">Sequence Header OBU</a> is present within the configOBUs, the values present in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①④">Sequence Header OBU</a> contained within configOBUs SHALL match the values of the AV1CodecConfigurationRecordv1 sequence parameters.</p>
-   <p>The presentation times of AV1 samples are given by the ISOBMFF structures. The <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①③">timing_info_present_flag</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑤">Sequence Header OBU</a> (in the configOBUs field or in the associated samples) SHOULD be set to 0. If set to 1, the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=45" id="ref-for-page=45">timing_info</a> structure of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑥">Sequence Header OBU</a>, the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①④">frame_presentation_time</a> and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑤">buffer_removal_time</a> fields of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49">Frame Header OBUs</a>, if present, SHALL be ignored for the purpose of timed processing of the ISOBMFF file.</p>
-   <p>If a <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-③">colr</a> box is present in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④">VisualSampleEntry</a> with a colour_type set to <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑤">nclx</a>, the values of colour_primaries, transfer_characteristics, and matrix_coefficients SHALL match the values given in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑦">Sequence Header OBU</a> (in the configOBUs field or in the associated samples) if the color_description_present_flag is set to 1. Similarly, the full_range_flag in the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑥">colr</a> box shall match the color_range flag in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑧">Sequence Header OBU</a>.</p>
-   <p>Additional boxes may be provided at the end of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-⑦">VisualSampleEntry</a> as permitted by ISOBMFF, that may represent redundant or similar information to the one provided in some OBUs contained in the <a data-link-type="dfn" href="#av1codecconfigurationbox" id="ref-for-av1codecconfigurationbox⑤">AV1CodecConfigurationBox</a>. If the box definition does not indicate that its information overrides the OBU information, in case of conflict, the OBU information should be considered authoritative.</p>
+   <p>OBUs stored in the configOBUs field follow the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①④">open_bitstream_unit</a> <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39①">Low Overhead Bitstream Format</a> syntax as specified in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>. The flag <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑤">obu_has_size_field</a> SHALL be set to 1, indicating that the size of the OBU payload follows the header, and that it is coded using LEB128.</p>
+   <p>The presentation times of AV1 samples are given by the ISOBMFF structures. The <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑥">timing_info_present_flag</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑨">Sequence Header OBU</a> (in the configOBUs field or in the associated samples) SHOULD be set to 0. If set to 1, the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=45" id="ref-for-page=45">timing_info</a> structure of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②⓪">Sequence Header OBU</a>, the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑦">frame_presentation_time</a> and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑧">buffer_removal_time</a> fields of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49">Frame Header OBUs</a>, if present, SHALL be ignored for the purpose of timed processing of the ISOBMFF file.</p>
+   <p>If a <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-③">colr</a> box is present in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④">VisualSampleEntry</a> with a colour_type set to <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑤">nclx</a>, the values of colour_primaries, transfer_characteristics, and matrix_coefficients SHALL match the values given in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②①">Sequence Header OBU</a> (in the configOBUs field or in the associated samples) if the color_description_present_flag is set to 1. Similarly, the full_range_flag in the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑥">colr</a> box shall match the color_range flag in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②②">Sequence Header OBU</a>.</p>
+   <p>When configOBUs does not contain a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②③">Sequence Header OBU</a> a <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑦">colr</a> box SHALL be present in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-⑧">VisualSampleEntry</a> with colour_type set to <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑨">nclx</a>.</p>
+   <p>Additional boxes may be provided at the end of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⓪">VisualSampleEntry</a> as permitted by ISOBMFF, that may represent redundant or similar information to the one provided in some OBUs contained in the <a data-link-type="dfn" href="#av1codecconfigurationbox" id="ref-for-av1codecconfigurationbox⑤">AV1CodecConfigurationBox</a>. If the box definition does not indicate that its information overrides the OBU information, in case of conflict, the OBU information should be considered authoritative.</p>
    <h3 class="heading settled" data-level="2.5" id="sampleformat"><span class="secno">2.5. </span><span class="content">AV1 Sample Format</span><a class="self-link" href="#sampleformat"></a></h3>
    <p>For tracks using the <a data-link-type="dfn" href="#av1sampleentry" id="ref-for-av1sampleentry②">AV1SampleEntry</a>, an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1-sample">AV1 Sample</dfn> has the following constraints:</p>
    <ul>
     <li data-md="">
      <p>the sample data SHALL be a sequence of <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39②">OBUs</a> forming a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑤">Temporal Unit</a>,</p>
     <li data-md="">
-     <p>each OBU SHALL follow the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑥">open_bitstream_unit</a> <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39③">Low Overhead Bitstream Format</a> syntax as specified in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>. Each OBU SHALL have the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑦">obu_has_size_field</a> set to 1 except for the last OBU in the sample, for which <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑧">obu_has_size_field</a> MAY be set to 0, in which case it is assumed to fill the remainder of the sample,</p>
+     <p>each OBU SHALL follow the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑨">open_bitstream_unit</a> <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39③">Low Overhead Bitstream Format</a> syntax as specified in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>. Each OBU SHALL have the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⓪">obu_has_size_field</a> set to 1 except for the last OBU in the sample, for which <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②①">obu_has_size_field</a> MAY be set to 0, in which case it is assumed to fill the remainder of the sample,</p>
    </ul>
-   <p class="note" role="note"><span>NOTE:</span> When extracting OBUs from an ISOBMFF file, and depending on the capabilities of the decoder processing these OBUs, ISOBMFF parsers MAY need to either: set the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑨">obu_has_size_field</a> to 1 for some OBUs if not already set, add the size field in this case, and add <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46">Temporal Delimiter OBU</a>; or use the length-delimited bitstream format as defined in Annex B of <a data-link-type="dfn" href="#av1s" id="ref-for-av1s">AV1</a>. If encryption is used, similar operations MAY have to be done before or after decryption depending on the demuxer/decryptor/decoder architecture.</p>
+   <p class="note" role="note"><span>NOTE:</span> When extracting OBUs from an ISOBMFF file, and depending on the capabilities of the decoder processing these OBUs, ISOBMFF parsers MAY need to either: set the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②②">obu_has_size_field</a> to 1 for some OBUs if not already set, add the size field in this case, and add <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46">Temporal Delimiter OBU</a>; or use the length-delimited bitstream format as defined in Annex B of <a data-link-type="dfn" href="#av1s" id="ref-for-av1s">AV1</a>. If encryption is used, similar operations MAY have to be done before or after decryption depending on the demuxer/decryptor/decoder architecture.</p>
    <ul>
     <li data-md="">
      <p>OBU trailing bits SHOULD be limited to byte alignment and SHOULD not be used for padding,</p>
@@ -1647,17 +1662,17 @@ aligned (8) class AV1CodecConfigurationRecordv1 {
    <p>If an AV1 Sample is signaled as a sync sample (in the SyncSampleBox or by setting sample_is_non_sync_sample to 0), it SHALL be a Random Access Point as defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>, i.e. satisfy the following constraints:</p>
    <ul>
     <li data-md="">
-     <p>Its first frame is a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑥">Key Frame</a> that has <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⓪">show_frame</a> flag set to 1,</p>
+     <p>Its first frame is a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑥">Key Frame</a> that has <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②③">show_frame</a> flag set to 1,</p>
     <li data-md="">
-     <p>It contains a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑨">Sequence Header OBU</a> before the first <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49①">Frame Header OBU</a>.</p>
+     <p>It contains a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②④">Sequence Header OBU</a> before the first <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49①">Frame Header OBU</a>.</p>
    </ul>
    <p class="note" role="note"><span>NOTE:</span> Within this definition, a sync sample may contain additional frames that are not Key Frames. The fact that none of them is the first frame in the temporal unit ensures that they are decodable.</p>
-   <p class="note" role="note"><span>NOTE:</span> Other types of OBUs such as <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47①">metadata OBUs</a> could be present before the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②⓪">Sequence Header OBU</a>.</p>
+   <p class="note" role="note"><span>NOTE:</span> Other types of OBUs such as <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47①">metadata OBUs</a> could be present before the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②⑤">Sequence Header OBU</a>.</p>
    <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑦">Intra-only frames</a> SHOULD be signaled using the sample_depends_on flag set to 2.</p>
    <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑦">Delayed Random Access Points</a> SHOULD be signaled using sample groups and the <a data-link-type="dfn" href="#av1forwardkeyframesamplegroupentry" id="ref-for-av1forwardkeyframesamplegroupentry①">AV1ForwardKeyFrameSampleGroupEntry</a>.</p>
    <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑧">Switch Frames</a> SHOULD be signaled using sample groups and the <a data-link-type="dfn" href="#av1switchframesamplegroupentry" id="ref-for-av1switchframesamplegroupentry">AV1SwitchFrameSampleGroupEntry</a>.</p>
-   <p>Additionally, if a file contains multiple tracks which are alternative representations of the same content, in particular using <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑨">Switch Frames</a>, those tracks SHOULD be marked as belonging to the same alternate group and should use a track selection box with an appropriate attribute (e.g. <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑧">bitr</a>).</p>
-   <p>Unlike many video standards, AV1 does not distinguish the display order from the decoding order, but achieves similar effects by grouping multiple frames within a sample. Therefore, composition offsets are not used. In tracks using the <a data-link-type="dfn" href="#av1sampleentry" id="ref-for-av1sampleentry③">AV1SampleEntry</a>, the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑨">ctts</a> box and composition offsets in movie fragments SHALL NOT be used. Similarly, the is_leading flag, if used, SHALL be set to 0 or 2.</p>
+   <p>Additionally, if a file contains multiple tracks which are alternative representations of the same content, in particular using <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑨">Switch Frames</a>, those tracks SHOULD be marked as belonging to the same alternate group and should use a track selection box with an appropriate attribute (e.g. <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-①①">bitr</a>).</p>
+   <p>Unlike many video standards, AV1 does not distinguish the display order from the decoding order, but achieves similar effects by grouping multiple frames within a sample. Therefore, composition offsets are not used. In tracks using the <a data-link-type="dfn" href="#av1sampleentry" id="ref-for-av1sampleentry③">AV1SampleEntry</a>, the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-①②">ctts</a> box and composition offsets in movie fragments SHALL NOT be used. Similarly, the is_leading flag, if used, SHALL be set to 0 or 2.</p>
    <p>When a temporal unit contains more than one frame, the sample corresponding to that temporal unit MAY be marked using the <a data-link-type="dfn" href="#av1multiframesamplegroupentry" id="ref-for-av1multiframesamplegroupentry">AV1MultiFrameSampleGroupEntry</a>.</p>
    <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47②">Metadata OBUs</a> may be carried in sample data. In this case, the <a data-link-type="dfn" href="#av1metadatasamplegroupentry" id="ref-for-av1metadatasamplegroupentry">AV1MetadataSampleGroupEntry</a> SHOULD be used. If the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47③">metadata OBUs</a> are static for the entire set of samples associated with a given sample description entry, they SHOULD also be in the OBU array in the sample description entry.</p>
    <p>Unless explicitely stated, the grouping_type_parameter is not defined for the SampleToGroupBox with grouping types defined in this specification.</p>
@@ -1721,7 +1736,7 @@ Quantity:   Zero or more.
    <p><dfn data-dfn-type="dfn" data-export="" id="metadata_type">metadata_type<a class="self-link" href="#metadata_type"></a></dfn> used by one OBU in the sample.</p>
    <h2 class="heading settled" data-level="3" id="cmaf"><span class="secno">3. </span><span class="content">CMAF AV1 track format and CMAF media profiles</span><a class="self-link" href="#cmaf"></a></h2>
    <p><a data-link-type="biblio" href="#biblio-cmaf">[CMAF]</a> defines structural constraints on ISOBMFF files additional to <a data-link-type="biblio" href="#biblio-isobmff">[ISOBMFF]</a> for the purpose of, for example, adaptive streaming or for protected files. <a data-link-type="biblio" href="#biblio-cmaf">[CMAF]</a> also relies on the signaling of CMAF Media Profiles. This document specifies CMAF Media Profiles and associated brands for AV1 bitstreams in CMAF-compliant files.</p>
-   <p>If a <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⓪">CMAF Video Track</a> signals one of the brands defined below, it is called a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="cmaf-av1-track">CMAF AV1 Track</dfn> and the following constraints apply:</p>
+   <p>If a <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①③">CMAF Video Track</a> signals one of the brands defined below, it is called a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="cmaf-av1-track">CMAF AV1 Track</dfn> and the following constraints apply:</p>
    <ul>
     <li data-md="">
      <p>it SHALL use an <a data-link-type="dfn" href="#av1sampleentry" id="ref-for-av1sampleentry④">AV1SampleEntry</a></p>
@@ -1736,7 +1751,7 @@ Quantity:   Zero or more.
        <p>color_config()</p>
      </ul>
     <li data-md="">
-     <p>the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-①①">colr</a> and <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-①②">pasp</a> boxes SHALL be present</p>
+     <p>the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-①④">colr</a> and <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-①⑤">pasp</a> boxes SHALL be present</p>
     <li data-md="">
      <p>for HDR profiles, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47⑤">metadata OBUs</a> of type METADATA_TYPE_HDR_CLL and METADATA_TYPE_HDR_MDCV should be present.</p>
    </ul>
@@ -1789,17 +1804,17 @@ Quantity:   Zero or more.
    <p class="issue" id="issue-e789b68e"><a class="self-link" href="#issue-e789b68e"></a> The content of table above needs to be discussed once the profiles and levels definition in the AV1 bitstream specification is finalized.</p>
    <h2 class="heading settled" data-level="4" id="CommonEncryption"><span class="secno">4. </span><span class="content">Common Encryption</span><a class="self-link" href="#CommonEncryption"></a></h2>
    <p><a data-link-type="dfn" href="#cmaf-av1-track" id="ref-for-cmaf-av1-track②">CMAF AV1 Tracks</a> and non-segmented AV1 files MAY be protected. If protected, they SHALL conform to <a data-link-type="biblio" href="#biblio-cenc">[CENC]</a>.</p>
-   <p>When the protected scheme <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①③">cenc</a></code> or <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①④">cbc1</a></code> is used, samples SHALL be protected using subsample encryption and SHALL NOT use pattern encryption.</p>
-   <p>When the protected scheme <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑤">cens</a></code> or <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑥">cbcs</a></code> is used, samples SHALL be protected using subsample encryption and SHALL use pattern encryption.</p>
+   <p>When the protected scheme <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑥">cenc</a></code> or <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑦">cbc1</a></code> is used, samples SHALL be protected using subsample encryption and SHALL NOT use pattern encryption.</p>
+   <p>When the protected scheme <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑧">cens</a></code> or <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑨">cbcs</a></code> is used, samples SHALL be protected using subsample encryption and SHALL use pattern encryption.</p>
    <h3 class="heading settled" data-level="4.1" id="subsample-encryption"><span class="secno">4.1. </span><span class="content">General Subsample Encryption constraints</span><a class="self-link" href="#subsample-encryption"></a></h3>
-   <p>When encrypting <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39④">OBUs</a>, all <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40">OBU Headers</a> and associated <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑨">obu_size</a> fields SHALL be unencrypted. Additionally, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46①">Temporal Delimiter OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑦">Sequence Header OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47⑥">Metadata OBUs</a> (except for those requiring protection), <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49②">Frame Header OBUs</a> SHALL be unencrypted.</p>
-   <p>Within encrypted samples, all <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40①">OBU Headers</a> and associated <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⓪">obu_size</a> fields SHALL be unencrypted. Additionally, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46②">Temporal Delimiter OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑧">Sequence Header OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47⑦">Metadata OBUs</a> (except for those requiring protection), <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49③">Frame Header OBUs</a> (including with a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71">Frame OBU</a>) SHALL be unencrypted. <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=72" id="ref-for-page=72">Tile Group OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71①">Frame OBUs</a> (except the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49④">Frame Header OBU</a> part) and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=121" id="ref-for-page=121">Tile List OBUs</a> MAY be encrypted. This is illustrated in Figure #1 and Figure #2, where for simplicity the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②①">obu_size</a> field is assumed to be part of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40②">OBU Header</a>.</p>
+   <p>Within protected samples, the following constraints apply:</p>
+   <ul>
     <li data-md="">
      <p>Protected samples SHALL be exactly spanned by one or more contiguous subsamples.</p>
     <li data-md="">
-     <p>all <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40">OBU Headers</a> and associated <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②①">obu_size</a> fields SHALL be unprotected.</p>
+     <p>all <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40">OBU Headers</a> and associated <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②④">obu_size</a> fields SHALL be unprotected.</p>
     <li data-md="">
-     <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46①">Temporal Delimiter OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⓪">Sequence Header OBUs</a>, and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49②">Frame Header OBUs</a> SHALL be unprotected.</p>
+     <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46①">Temporal Delimiter OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②⑥">Sequence Header OBUs</a>, and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49②">Frame Header OBUs</a> SHALL be unprotected.</p>
     <li data-md="">
      <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47⑥">Metadata OBUs</a> MAY be protected.</p>
     <li data-md="">
@@ -1809,18 +1824,18 @@ Quantity:   Zero or more.
     <li data-md="">
      <p>Within <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=121" id="ref-for-page=121①">Tile List OBUs</a>, only the <code>coded_tile_data</code> part SHALL be protected.</p>
     <li data-md="">
-     <p><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑦">BytesOfProtectedData</a> size SHALL be a multiple of 16 bytes to avoid partial cipher blocks in subsamples.</p>
+     <p><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-②⓪">BytesOfProtectedData</a> size SHALL be a multiple of 16 bytes to avoid partial cipher blocks in subsamples.</p>
     <li data-md="">
-     <p>A protected OBU SHOULD be spanned by a single subsample. However, when the protected OBU data size is larger than the maximum size of a single <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑧">BytesOfProtectedData</a> field, then the OBU MAY be spanned by additional subsamples with <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑨">BytesOfClearData</a> size equal to zero.</p>
+     <p>A protected OBU SHOULD be spanned by a single subsample. However, when the protected OBU data size is larger than the maximum size of a single <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-②①">BytesOfProtectedData</a> field, then the OBU MAY be spanned by additional subsamples with <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-②②">BytesOfClearData</a> size equal to zero.</p>
     <li data-md="">
-     <p>Multiple unprotected OBUs SHOULD be spanned by a single subsample clear range, but a large clear range MAY be spanned by multiple subsamples with zero size <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-②⓪">BytesOfProtectedData</a>.</p>
+     <p>Multiple unprotected OBUs SHOULD be spanned by a single subsample clear range, but a large clear range MAY be spanned by multiple subsamples with zero size <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-②③">BytesOfProtectedData</a>.</p>
    </ul>
    <h3 class="heading settled" data-level="4.2" id="ctr-subsample-encryption"><span class="secno">4.2. </span><span class="content">Subsample encryption using AES-CTR</span><a class="self-link" href="#ctr-subsample-encryption"></a></h3>
-    For AES-CTR based scheme types, such as <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-②①">cenc</a></code>, the encrypted bytes of each OBU within the sample SHALL be block-aligned so that the counter state can be computed for each OBU within the sample. Block alignment is achieved by adjusting the size of the unencrypted bytes that precede the encrypted bytes for that OBU. In other words, partial blocks are not permitted. 
-   <p>For AES-CBC based scheme types, such as <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑦">cbcs</a></code>, <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑧">BytesOfProtectedData</a> SHALL start on the first complete byte of OBU data that is permitted to be encrypted (i.e. after the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40③">OBU Header</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②④">obu_size</a>, possible <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49⑤">Frame Header OBU</a> and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⑤">byte_alignment</a>), and end on the end of the last complete 16-byte block of data in the OBU. Partial blocks at the end of OBUs, if any, SHALL be left unencrypted as specified in <a data-link-type="biblio" href="#biblio-cenc">[CENC]</a>.</p>
-    For AES-CBC based scheme types, such as <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-②②">cbcs</a></code>, <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-②③">BytesOfProtectedData</a> SHALL start on the first complete byte of OBU data that is permitted to be protected, and end on the end of the last complete 16-byte block of data in the OBU. In other words, partial blocks at the end of OBUs, if any, SHALL be left unprotected. 
+    For AES-CTR based scheme types, such as <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-②④">cenc</a></code>, the encrypted bytes of each OBU within the sample SHALL be block-aligned so that the counter state can be computed for each OBU within the sample. Block alignment is achieved by adjusting the size of the unencrypted bytes that precede the encrypted bytes for that OBU. In other words, partial blocks are not permitted. 
+   <h3 class="heading settled" data-level="4.3" id="cbc-subsample-encryption"><span class="secno">4.3. </span><span class="content">Subsample encryption using AES-CBC</span><a class="self-link" href="#cbc-subsample-encryption"></a></h3>
+    For AES-CBC based scheme types, such as <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-②⑤">cbcs</a></code>, <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-②⑥">BytesOfProtectedData</a> SHALL start on the first complete byte of OBU data that is permitted to be protected, and end on the end of the last complete 16-byte block of data in the OBU. In other words, partial blocks at the end of OBUs, if any, SHALL be left unprotected. 
    <h3 class="heading settled" data-level="4.4" id="subsample-encryption-illustration"><span class="secno">4.4. </span><span class="content">Illustration</span><a class="self-link" href="#subsample-encryption-illustration"></a></h3>
-   <p>This is illustrated in Figure #1 and Figure #2, where for simplicity the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②②">obu_size</a> field is assumed to be part of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40①">OBU Header</a>.</p>
+   <p>This is illustrated in Figure #1 and Figure #2, where for simplicity the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⑤">obu_size</a> field is assumed to be part of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40①">OBU Header</a>.</p>
    <figure>
      <img alt="Simplified subsample-based AV1 encryption" src="images/subsample-encryption-no-type.svg"> 
     <figcaption>Subsample-based AV1 encryption with clear OBU headers with OBU types omitted.</figcaption>
@@ -1830,18 +1845,18 @@ Quantity:   Zero or more.
     <figcaption>Subsample-based AV1 encryption with clear OBU headers including OBU types.</figcaption>
    </figure>
    <h2 class="heading settled" data-level="5" id="codecsparam"><span class="secno">5. </span><span class="content">Codecs Parameter String</span><a class="self-link" href="#codecsparam"></a></h2>
-   <p>DASH and other applications require defined values for the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-②④">Codecs</a> parameter specified in <a data-link-type="biblio" href="#biblio-rfc6381">[RFC6381]</a> for ISO Media tracks. The codecs parameter string for the AOM AV1 codec is as follows:</p>
+   <p>DASH and other applications require defined values for the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-②⑦">Codecs</a> parameter specified in <a data-link-type="biblio" href="#biblio-rfc6381">[RFC6381]</a> for ISO Media tracks. The codecs parameter string for the AOM AV1 codec is as follows:</p>
 <pre>&lt;sample entry 4CC>.&lt;profile>.&lt;level>&lt;tier>.&lt;bitDepth>.&lt;monochrome>.&lt;chromaSubsampling>.
 &lt;colorPrimaries>.&lt;transferCharacteristics>.&lt;matrixCoefficients>.&lt;videoFullRangeFlag>
 </pre>
    <p>All fields following the sample entry 4CC are expressed as double digit decimals, unless indicated otherwise. Leading or trailing zeros cannot be omitted.</p>
-   <p>The profile parameter value, represented by a single digit decimal, SHALL equal the value of seq_profile in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑨">Sequence Header OBU</a>.</p>
-   <p>The level parameter value SHALL equal the first level value indicated by <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②④">seq_level_idx</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②⓪">Sequence Header OBU</a>.</p>
-   <p>The tier parameter value SHALL be equal to <code>M</code> when the first <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⑤">seq_tier</a> value in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②①">Sequence Header OBU</a> is equal to 0, and <code>H</code> when it is equal to 1.</p>
-   <p>The bitDepth parameter value SHALL equal the value of BitDepth variable as defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> derived from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②②">Sequence Header OBU</a>.</p>
-   <p>The monochrome parameter value, represented by a single digit decimal, SHALL equal the value of mono_chrome in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②③">Sequence Header OBU</a>.</p>
+   <p>The profile parameter value, represented by a single digit decimal, SHALL equal the value of seq_profile in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②⑦">Sequence Header OBU</a>.</p>
+   <p>The level parameter value SHALL equal the first level value indicated by <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⑥">seq_level_idx</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②⑧">Sequence Header OBU</a>.</p>
+   <p>The tier parameter value SHALL be equal to <code>M</code> when the first <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⑦">seq_tier</a> value in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②⑨">Sequence Header OBU</a> is equal to 0, and <code>H</code> when it is equal to 1.</p>
+   <p>The bitDepth parameter value SHALL equal the value of BitDepth variable as defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> derived from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41③⓪">Sequence Header OBU</a>.</p>
+   <p>The monochrome parameter value, represented by a single digit decimal, SHALL equal the value of mono_chrome in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41③①">Sequence Header OBU</a>.</p>
    <p>The chromaSubsampling parameter value, represented by a three-digit decimal, SHALL have its first digit equal to subsampling_x and its second digit equal to subsampling_y. If both subsampling_x and subsampling_y are set to 1, then the third digit SHALL be equal to chroma_sample_position, otherwise it SHALL be set to 0.</p>
-   <p>The colorPrimaries, transferCharacteristics, matrixCoefficients and videoFullRangeFlag parameter values SHALL equal the value of matching fields in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②④">Sequence Header OBU</a>, if color_description_present_flag is set to 1, otherwise they SHOULD not be set, defaulting to the values below. The videoFullRangeFlag is represented by a single digit.</p>
+   <p>The colorPrimaries, transferCharacteristics, matrixCoefficients and videoFullRangeFlag parameter values SHALL equal the value of matching fields in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41③②">Sequence Header OBU</a>, if color_description_present_flag is set to 1, otherwise they SHOULD not be set, defaulting to the values below. The videoFullRangeFlag is represented by a single digit.</p>
    <p>For example, codecs="av01.0.04M.10.0.112.09.16.09.0" represents AV1 profile 0, level 3.0, Main tier, 10-bit content, non-monochrome, with 4:2:0 chroma subsampling, ITU-R BT.2100 color primaries, ITU BT.2100 PQ transfer characteristics, ITU-R BT.2100 YCbCr color matrix, and studio swing representation.</p>
    <p>The parameters sample entry 4CC, profile, level, tier, and bitDepth are all mandatory fields. If any of these fields are empty, or not within their allowed range, the processing device SHOULD treat it as an error.</p>
    <p>All the other fields (including their leading '.') are optional, mutually inclusive (all or none) fields. If not specified then the values listed in the table below are assumed.</p>
@@ -2037,6 +2052,9 @@ Quantity:   Zero or more.
    <li><a href="#av1sampleentry">AV1SampleEntry</a><span>, in §2.3.2</span>
    <li><a href="#av1switchframesamplegroupentry">AV1SwitchFrameSampleGroupEntry</a><span>, in §2.8.2</span>
    <li><a href="#bit_depth">bit_depth</a><span>, in §2.4.4</span>
+   <li><a href="#chroma_sample_position">chroma_sample_position</a><span>, in §2.4.4</span>
+   <li><a href="#chroma_subsampling_x">chroma_subsampling_x</a><span>, in §2.4.4</span>
+   <li><a href="#chroma_subsampling_y">chroma_subsampling_y</a><span>, in §2.4.4</span>
    <li><a href="#cmaf-av1-track">CMAF AV1 Track</a><span>, in §3</span>
    <li><a href="#compressorname">compressorname</a><span>, in §2.3.4</span>
    <li><a href="#config">config</a><span>, in §2.3.4</span>
@@ -2046,11 +2064,13 @@ Quantity:   Zero or more.
    <li><a href="#initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</a><span>, in §2.4.4</span>
    <li><a href="#initial_presentation_delay_present">initial_presentation_delay_present</a><span>, in §2.4.4</span>
    <li><a href="#metadata_type">metadata_type</a><span>, in §2.9.4</span>
+   <li><a href="#monochrome">monochrome</a><span>, in §2.4.4</span>
    <li><a href="#seq_level_idx_0">seq_level_idx_0</a><span>, in §2.4.4</span>
    <li><a href="#seq_profile">seq_profile</a><span>, in §2.4.4</span>
    <li><a href="#seq_tier_0">seq_tier_0</a><span>, in §2.4.4</span>
    <li><a href="#sequence_parameters_present">sequence_parameters_present</a><span>, in §2.4.4</span>
    <li><a href="#still_picture">still_picture</a><span>, in §2.4.4</span>
+   <li><a href="#version">version</a><span>, in §2.4.4</span>
    <li><a href="#width">width</a><span>, in §2.3.4</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-page=1">
@@ -2065,14 +2085,10 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
-    <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
-    <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a> <a href="#ref-for-page=2①⑥">(9)</a> <a href="#ref-for-page=2①⑦">(10)</a> <a href="#ref-for-page=2①⑧">(11)</a>
+    <li><a href="#ref-for-page=2①⑨">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2②⓪">(2)</a> <a href="#ref-for-page=2②①">(3)</a> <a href="#ref-for-page=2②②">(4)</a> <a href="#ref-for-page=2②③">(5)</a>
+    <li><a href="#ref-for-page=2②④">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2②⑤">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
@@ -2104,10 +2120,10 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
-    <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a> <a href="#ref-for-page=2①⑥">(9)</a> <a href="#ref-for-page=2①⑦">(10)</a> <a href="#ref-for-page=2①⑧">(11)</a>
+    <li><a href="#ref-for-page=2①⑨">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2②⓪">(2)</a> <a href="#ref-for-page=2②①">(3)</a> <a href="#ref-for-page=2②②">(4)</a> <a href="#ref-for-page=2②③">(5)</a>
+    <li><a href="#ref-for-page=2②④">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2②⑤">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
@@ -2116,10 +2132,10 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
-    <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a> <a href="#ref-for-page=2①⑥">(9)</a> <a href="#ref-for-page=2①⑦">(10)</a> <a href="#ref-for-page=2①⑧">(11)</a>
+    <li><a href="#ref-for-page=2①⑨">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2②⓪">(2)</a> <a href="#ref-for-page=2②①">(3)</a> <a href="#ref-for-page=2②②">(4)</a> <a href="#ref-for-page=2②③">(5)</a>
+    <li><a href="#ref-for-page=2②④">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2②⑤">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
@@ -2169,10 +2185,10 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
-    <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a> <a href="#ref-for-page=2①⑥">(9)</a> <a href="#ref-for-page=2①⑦">(10)</a> <a href="#ref-for-page=2①⑧">(11)</a>
+    <li><a href="#ref-for-page=2①⑨">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2②⓪">(2)</a> <a href="#ref-for-page=2②①">(3)</a> <a href="#ref-for-page=2②②">(4)</a> <a href="#ref-for-page=2②③">(5)</a>
+    <li><a href="#ref-for-page=2②④">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2②⑤">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
@@ -2181,10 +2197,10 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
-    <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a> <a href="#ref-for-page=2①⑥">(9)</a> <a href="#ref-for-page=2①⑦">(10)</a> <a href="#ref-for-page=2①⑧">(11)</a>
+    <li><a href="#ref-for-page=2①⑨">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2②⓪">(2)</a> <a href="#ref-for-page=2②①">(3)</a> <a href="#ref-for-page=2②②">(4)</a> <a href="#ref-for-page=2②③">(5)</a>
+    <li><a href="#ref-for-page=2②④">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2②⑤">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
@@ -2196,6 +2212,18 @@ Quantity:   Zero or more.
     <li><a href="#ref-for-page=47④">2.9.2. Description</a>
     <li><a href="#ref-for-page=47⑤">3. CMAF AV1 track format and CMAF media profiles</a>
     <li><a href="#ref-for-page=47⑥">4.1. General Subsample Encryption constraints</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-page=2">
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
+    <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a> <a href="#ref-for-page=2①⑥">(9)</a> <a href="#ref-for-page=2①⑦">(10)</a> <a href="#ref-for-page=2①⑧">(11)</a>
+    <li><a href="#ref-for-page=2①⑨">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2②⓪">(2)</a> <a href="#ref-for-page=2②①">(3)</a> <a href="#ref-for-page=2②②">(4)</a> <a href="#ref-for-page=2②③">(5)</a>
+    <li><a href="#ref-for-page=2②④">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2②⑤">4.4. Illustration</a>
+    <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=39">
@@ -2218,10 +2246,10 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
-    <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a> <a href="#ref-for-page=2①⑥">(9)</a> <a href="#ref-for-page=2①⑦">(10)</a> <a href="#ref-for-page=2①⑧">(11)</a>
+    <li><a href="#ref-for-page=2①⑨">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2②⓪">(2)</a> <a href="#ref-for-page=2②①">(3)</a> <a href="#ref-for-page=2②②">(4)</a> <a href="#ref-for-page=2②③">(5)</a>
+    <li><a href="#ref-for-page=2②④">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2②⑤">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
@@ -2230,10 +2258,10 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
-    <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a> <a href="#ref-for-page=2①⑥">(9)</a> <a href="#ref-for-page=2①⑦">(10)</a> <a href="#ref-for-page=2①⑧">(11)</a>
+    <li><a href="#ref-for-page=2①⑨">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2②⓪">(2)</a> <a href="#ref-for-page=2②①">(3)</a> <a href="#ref-for-page=2②②">(4)</a> <a href="#ref-for-page=2②③">(5)</a>
+    <li><a href="#ref-for-page=2②④">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2②⑤">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
@@ -2242,10 +2270,10 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
-    <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a> <a href="#ref-for-page=2①⑥">(9)</a> <a href="#ref-for-page=2①⑦">(10)</a> <a href="#ref-for-page=2①⑧">(11)</a>
+    <li><a href="#ref-for-page=2①⑨">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2②⓪">(2)</a> <a href="#ref-for-page=2②①">(3)</a> <a href="#ref-for-page=2②②">(4)</a> <a href="#ref-for-page=2②③">(5)</a>
+    <li><a href="#ref-for-page=2②④">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2②⑤">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
@@ -2263,10 +2291,10 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
-    <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a> <a href="#ref-for-page=2①⑥">(9)</a> <a href="#ref-for-page=2①⑦">(10)</a> <a href="#ref-for-page=2①⑧">(11)</a>
+    <li><a href="#ref-for-page=2①⑨">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2②⓪">(2)</a> <a href="#ref-for-page=2②①">(3)</a> <a href="#ref-for-page=2②②">(4)</a> <a href="#ref-for-page=2②③">(5)</a>
+    <li><a href="#ref-for-page=2②④">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2②⑤">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
@@ -2275,10 +2303,10 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
-    <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a> <a href="#ref-for-page=2①⑥">(9)</a> <a href="#ref-for-page=2①⑦">(10)</a> <a href="#ref-for-page=2①⑧">(11)</a>
+    <li><a href="#ref-for-page=2①⑨">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2②⓪">(2)</a> <a href="#ref-for-page=2②①">(3)</a> <a href="#ref-for-page=2②②">(4)</a> <a href="#ref-for-page=2②③">(5)</a>
+    <li><a href="#ref-for-page=2②④">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2②⑤">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
@@ -2286,10 +2314,10 @@ Quantity:   Zero or more.
    <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=41">2.3.4. Semantics</a> <a href="#ref-for-page=41①">(2)</a>
-    <li><a href="#ref-for-page=41②">2.4.4. Semantics</a> <a href="#ref-for-page=41③">(2)</a> <a href="#ref-for-page=41④">(3)</a> <a href="#ref-for-page=41⑤">(4)</a> <a href="#ref-for-page=41⑥">(5)</a> <a href="#ref-for-page=41⑦">(6)</a> <a href="#ref-for-page=41⑧">(7)</a> <a href="#ref-for-page=41⑨">(8)</a> <a href="#ref-for-page=41①⓪">(9)</a> <a href="#ref-for-page=41①①">(10)</a> <a href="#ref-for-page=41①②">(11)</a> <a href="#ref-for-page=41①③">(12)</a> <a href="#ref-for-page=41①④">(13)</a> <a href="#ref-for-page=41①⑤">(14)</a> <a href="#ref-for-page=41①⑥">(15)</a> <a href="#ref-for-page=41①⑦">(16)</a> <a href="#ref-for-page=41①⑧">(17)</a>
-    <li><a href="#ref-for-page=41①⑨">2.5. AV1 Sample Format</a> <a href="#ref-for-page=41②⓪">(2)</a>
-    <li><a href="#ref-for-page=41①⑦">4.1. Sample Encryption</a> <a href="#ref-for-page=41①⑧">(2)</a>
-    <li><a href="#ref-for-page=41①⑨">5. Codecs Parameter String</a> <a href="#ref-for-page=41②⓪">(2)</a> <a href="#ref-for-page=41②①">(3)</a> <a href="#ref-for-page=41②②">(4)</a> <a href="#ref-for-page=41②③">(5)</a> <a href="#ref-for-page=41②④">(6)</a>
+    <li><a href="#ref-for-page=41②">2.4.4. Semantics</a> <a href="#ref-for-page=41③">(2)</a> <a href="#ref-for-page=41④">(3)</a> <a href="#ref-for-page=41⑤">(4)</a> <a href="#ref-for-page=41⑥">(5)</a> <a href="#ref-for-page=41⑦">(6)</a> <a href="#ref-for-page=41⑧">(7)</a> <a href="#ref-for-page=41⑨">(8)</a> <a href="#ref-for-page=41①⓪">(9)</a> <a href="#ref-for-page=41①①">(10)</a> <a href="#ref-for-page=41①②">(11)</a> <a href="#ref-for-page=41①③">(12)</a> <a href="#ref-for-page=41①④">(13)</a> <a href="#ref-for-page=41①⑤">(14)</a> <a href="#ref-for-page=41①⑥">(15)</a> <a href="#ref-for-page=41①⑦">(16)</a> <a href="#ref-for-page=41①⑧">(17)</a> <a href="#ref-for-page=41①⑨">(18)</a> <a href="#ref-for-page=41②⓪">(19)</a> <a href="#ref-for-page=41②①">(20)</a> <a href="#ref-for-page=41②②">(21)</a> <a href="#ref-for-page=41②③">(22)</a>
+    <li><a href="#ref-for-page=41②④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=41②⑤">(2)</a>
+    <li><a href="#ref-for-page=41②⑥">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=41②⑦">5. Codecs Parameter String</a> <a href="#ref-for-page=41②⑧">(2)</a> <a href="#ref-for-page=41②⑨">(3)</a> <a href="#ref-for-page=41③⓪">(4)</a> <a href="#ref-for-page=41③①">(5)</a> <a href="#ref-for-page=41③②">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
@@ -2297,10 +2325,10 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
-    <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a> <a href="#ref-for-page=2①⑥">(9)</a> <a href="#ref-for-page=2①⑦">(10)</a> <a href="#ref-for-page=2①⑧">(11)</a>
+    <li><a href="#ref-for-page=2①⑨">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2②⓪">(2)</a> <a href="#ref-for-page=2②①">(3)</a> <a href="#ref-for-page=2②②">(4)</a> <a href="#ref-for-page=2②③">(5)</a>
+    <li><a href="#ref-for-page=2②④">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2②⑤">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
@@ -2309,10 +2337,34 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
-    <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a> <a href="#ref-for-page=2①⑥">(9)</a> <a href="#ref-for-page=2①⑦">(10)</a> <a href="#ref-for-page=2①⑧">(11)</a>
+    <li><a href="#ref-for-page=2①⑨">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2②⓪">(2)</a> <a href="#ref-for-page=2②①">(3)</a> <a href="#ref-for-page=2②②">(4)</a> <a href="#ref-for-page=2②③">(5)</a>
+    <li><a href="#ref-for-page=2②④">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2②⑤">4.4. Illustration</a>
+    <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-page=2">
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
+    <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a> <a href="#ref-for-page=2①⑥">(9)</a> <a href="#ref-for-page=2①⑦">(10)</a> <a href="#ref-for-page=2①⑧">(11)</a>
+    <li><a href="#ref-for-page=2①⑨">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2②⓪">(2)</a> <a href="#ref-for-page=2②①">(3)</a> <a href="#ref-for-page=2②②">(4)</a> <a href="#ref-for-page=2②③">(5)</a>
+    <li><a href="#ref-for-page=2②④">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2②⑤">4.4. Illustration</a>
+    <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-page=2">
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
+    <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a> <a href="#ref-for-page=2①⑥">(9)</a> <a href="#ref-for-page=2①⑦">(10)</a> <a href="#ref-for-page=2①⑧">(11)</a>
+    <li><a href="#ref-for-page=2①⑨">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2②⓪">(2)</a> <a href="#ref-for-page=2②①">(3)</a> <a href="#ref-for-page=2②②">(4)</a> <a href="#ref-for-page=2②③">(5)</a>
+    <li><a href="#ref-for-page=2②④">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2②⑤">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
@@ -2362,10 +2414,10 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
-    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
-    <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
-    <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a> <a href="#ref-for-page=2①⑥">(9)</a> <a href="#ref-for-page=2①⑦">(10)</a> <a href="#ref-for-page=2①⑧">(11)</a>
+    <li><a href="#ref-for-page=2①⑨">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2②⓪">(2)</a> <a href="#ref-for-page=2②①">(3)</a> <a href="#ref-for-page=2②②">(4)</a> <a href="#ref-for-page=2②③">(5)</a>
+    <li><a href="#ref-for-page=2②④">4.1. General Subsample Encryption constraints</a>
+    <li><a href="#ref-for-page=2②⑤">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
    </ul>
   </aside>
@@ -2373,7 +2425,7 @@ Quantity:   Zero or more.
    <a href="http://iso.org/#">http://iso.org/#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.3.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
-    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
+    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
     <li><a href="#termref-for-">2.5. AV1 Sample Format</a> <a href="#termref-for-">(2)</a>
     <li><a href="#termref-for-">3. CMAF AV1 track format and CMAF media profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
     <li><a href="#termref-for-">4. Common Encryption</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
@@ -2387,7 +2439,7 @@ Quantity:   Zero or more.
    <a href="http://iso.org/#">http://iso.org/#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.3.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
-    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
+    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
     <li><a href="#termref-for-">2.5. AV1 Sample Format</a> <a href="#termref-for-">(2)</a>
     <li><a href="#termref-for-">3. CMAF AV1 track format and CMAF media profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
     <li><a href="#termref-for-">4. Common Encryption</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
@@ -2401,7 +2453,7 @@ Quantity:   Zero or more.
    <a href="http://iso.org/#">http://iso.org/#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.3.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
-    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
+    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
     <li><a href="#termref-for-">2.5. AV1 Sample Format</a> <a href="#termref-for-">(2)</a>
     <li><a href="#termref-for-">3. CMAF AV1 track format and CMAF media profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
     <li><a href="#termref-for-">4. Common Encryption</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
@@ -2415,7 +2467,7 @@ Quantity:   Zero or more.
    <a href="http://iso.org/#">http://iso.org/#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.3.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
-    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
+    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
     <li><a href="#termref-for-">2.5. AV1 Sample Format</a> <a href="#termref-for-">(2)</a>
     <li><a href="#termref-for-">3. CMAF AV1 track format and CMAF media profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
     <li><a href="#termref-for-">4. Common Encryption</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
@@ -2429,7 +2481,7 @@ Quantity:   Zero or more.
    <a href="http://iso.org/#">http://iso.org/#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.3.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
-    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
+    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
     <li><a href="#termref-for-">2.5. AV1 Sample Format</a> <a href="#termref-for-">(2)</a>
     <li><a href="#termref-for-">3. CMAF AV1 track format and CMAF media profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
     <li><a href="#termref-for-">4. Common Encryption</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
@@ -2443,7 +2495,7 @@ Quantity:   Zero or more.
    <a href="http://iso.org/#">http://iso.org/#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.3.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
-    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
+    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
     <li><a href="#termref-for-">2.5. AV1 Sample Format</a> <a href="#termref-for-">(2)</a>
     <li><a href="#termref-for-">3. CMAF AV1 track format and CMAF media profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
     <li><a href="#termref-for-">4. Common Encryption</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
@@ -2457,7 +2509,7 @@ Quantity:   Zero or more.
    <a href="http://iso.org/#">http://iso.org/#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.3.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
-    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
+    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
     <li><a href="#termref-for-">2.5. AV1 Sample Format</a> <a href="#termref-for-">(2)</a>
     <li><a href="#termref-for-">3. CMAF AV1 track format and CMAF media profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
     <li><a href="#termref-for-">4. Common Encryption</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
@@ -2471,7 +2523,7 @@ Quantity:   Zero or more.
    <a href="http://iso.org/#">http://iso.org/#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.3.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
-    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
+    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
     <li><a href="#termref-for-">2.5. AV1 Sample Format</a> <a href="#termref-for-">(2)</a>
     <li><a href="#termref-for-">3. CMAF AV1 track format and CMAF media profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
     <li><a href="#termref-for-">4. Common Encryption</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
@@ -2485,7 +2537,7 @@ Quantity:   Zero or more.
    <a href="http://iso.org/#">http://iso.org/#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.3.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
-    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
+    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
     <li><a href="#termref-for-">2.5. AV1 Sample Format</a> <a href="#termref-for-">(2)</a>
     <li><a href="#termref-for-">3. CMAF AV1 track format and CMAF media profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
     <li><a href="#termref-for-">4. Common Encryption</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
@@ -2499,7 +2551,7 @@ Quantity:   Zero or more.
    <a href="http://iso.org/#">http://iso.org/#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.3.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
-    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
+    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
     <li><a href="#termref-for-">2.5. AV1 Sample Format</a> <a href="#termref-for-">(2)</a>
     <li><a href="#termref-for-">3. CMAF AV1 track format and CMAF media profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
     <li><a href="#termref-for-">4. Common Encryption</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
@@ -2513,7 +2565,7 @@ Quantity:   Zero or more.
    <a href="http://iso.org/#">http://iso.org/#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.3.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
-    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
+    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
     <li><a href="#termref-for-">2.5. AV1 Sample Format</a> <a href="#termref-for-">(2)</a>
     <li><a href="#termref-for-">3. CMAF AV1 track format and CMAF media profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
     <li><a href="#termref-for-">4. Common Encryption</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
@@ -2527,7 +2579,7 @@ Quantity:   Zero or more.
    <a href="http://iso.org/#">http://iso.org/#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.3.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
-    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
+    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
     <li><a href="#termref-for-">2.5. AV1 Sample Format</a> <a href="#termref-for-">(2)</a>
     <li><a href="#termref-for-">3. CMAF AV1 track format and CMAF media profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
     <li><a href="#termref-for-">4. Common Encryption</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
@@ -2541,7 +2593,7 @@ Quantity:   Zero or more.
    <a href="http://iso.org/#">http://iso.org/#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.3.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
-    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
+    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
     <li><a href="#termref-for-">2.5. AV1 Sample Format</a> <a href="#termref-for-">(2)</a>
     <li><a href="#termref-for-">3. CMAF AV1 track format and CMAF media profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
     <li><a href="#termref-for-">4. Common Encryption</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
@@ -2555,7 +2607,7 @@ Quantity:   Zero or more.
    <a href="http://iso.org/#">http://iso.org/#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.3.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
-    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a>
+    <li><a href="#termref-for-">2.4.4. Semantics</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a>
     <li><a href="#termref-for-">2.5. AV1 Sample Format</a> <a href="#termref-for-">(2)</a>
     <li><a href="#termref-for-">3. CMAF AV1 track format and CMAF media profiles</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
     <li><a href="#termref-for-">4. Common Encryption</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
@@ -2576,33 +2628,36 @@ Quantity:   Zero or more.
      <li><span class="dfn-paneled" id="term-for-page=49" style="color:initial">frame header obu</span>
      <li><span class="dfn-paneled" id="term-for-page=71" style="color:initial">frame obu</span>
      <li><span class="dfn-paneled" id="term-for-page=2①" style="color:initial">frame_presentation_time</span>
-     <li><span class="dfn-paneled" id="term-for-page=2③" style="color:initial">initial_display_delay_minus_1</span>
+     <li><span class="dfn-paneled" id="term-for-page=2②" style="color:initial">initial_display_delay_minus_1</span>
      <li><span class="dfn-paneled" id="term-for-page=13" style="color:initial">inter frame</span>
      <li><span class="dfn-paneled" id="term-for-page=13①" style="color:initial">intra-only frame</span>
      <li><span class="dfn-paneled" id="term-for-page=13②" style="color:initial">key frame</span>
      <li><span class="dfn-paneled" id="term-for-page=206①" style="color:initial">key frame dependent recovery point</span>
      <li><span class="dfn-paneled" id="term-for-page=39" style="color:initial">low overhead bitstream format</span>
-     <li><span class="dfn-paneled" id="term-for-page=2④" style="color:initial">max_frame_height_minus_1</span>
-     <li><span class="dfn-paneled" id="term-for-page=2⑤" style="color:initial">max_frame_width_minus_1</span>
+     <li><span class="dfn-paneled" id="term-for-page=2③" style="color:initial">max_frame_height_minus_1</span>
+     <li><span class="dfn-paneled" id="term-for-page=2④" style="color:initial">max_frame_width_minus_1</span>
      <li><span class="dfn-paneled" id="term-for-page=47" style="color:initial">metadata obu</span>
+     <li><span class="dfn-paneled" id="term-for-page=2⑤" style="color:initial">mono_chrome</span>
      <li><span class="dfn-paneled" id="term-for-page=39①" style="color:initial">obu</span>
      <li><span class="dfn-paneled" id="term-for-page=40" style="color:initial">obu header</span>
-     <li><span class="dfn-paneled" id="term-for-page=2⑤" style="color:initial">obu_has_size_field</span>
-     <li><span class="dfn-paneled" id="term-for-page=2⑥" style="color:initial">obu_size</span>
-     <li><span class="dfn-paneled" id="term-for-page=2⑦" style="color:initial">open_bitstream_unit</span>
+     <li><span class="dfn-paneled" id="term-for-page=2⑥" style="color:initial">obu_has_size_field</span>
+     <li><span class="dfn-paneled" id="term-for-page=2⑦" style="color:initial">obu_size</span>
+     <li><span class="dfn-paneled" id="term-for-page=2⑧" style="color:initial">open_bitstream_unit</span>
      <li><span class="dfn-paneled" id="term-for-page=206②" style="color:initial">random access point</span>
-     <li><span class="dfn-paneled" id="term-for-page=2⑧" style="color:initial">seq_level_idx</span>
-     <li><span class="dfn-paneled" id="term-for-page=2⑨" style="color:initial">seq_tier</span>
+     <li><span class="dfn-paneled" id="term-for-page=2⑨" style="color:initial">seq_level_idx</span>
+     <li><span class="dfn-paneled" id="term-for-page=2①⓪" style="color:initial">seq_tier</span>
      <li><span class="dfn-paneled" id="term-for-page=41" style="color:initial">sequence header obu</span>
-     <li><span class="dfn-paneled" id="term-for-page=2①⓪" style="color:initial">show_existing_frame</span>
-     <li><span class="dfn-paneled" id="term-for-page=2①①" style="color:initial">show_frame</span>
+     <li><span class="dfn-paneled" id="term-for-page=2①①" style="color:initial">show_existing_frame</span>
+     <li><span class="dfn-paneled" id="term-for-page=2①②" style="color:initial">show_frame</span>
+     <li><span class="dfn-paneled" id="term-for-page=2①③" style="color:initial">subsampling_x</span>
+     <li><span class="dfn-paneled" id="term-for-page=2①④" style="color:initial">subsampling_y</span>
      <li><span class="dfn-paneled" id="term-for-page=13③" style="color:initial">switch frame</span>
      <li><span class="dfn-paneled" id="term-for-page=46" style="color:initial">temporal delimiter obu</span>
      <li><span class="dfn-paneled" id="term-for-page=13④" style="color:initial">temporal unit</span>
      <li><span class="dfn-paneled" id="term-for-page=72" style="color:initial">tile group obu</span>
      <li><span class="dfn-paneled" id="term-for-page=121" style="color:initial">tile list obu</span>
      <li><span class="dfn-paneled" id="term-for-page=45" style="color:initial">timing_info</span>
-     <li><span class="dfn-paneled" id="term-for-page=2①②" style="color:initial">timing_info_present_flag</span>
+     <li><span class="dfn-paneled" id="term-for-page=2①⑤" style="color:initial">timing_info_present_flag</span>
     </ul>
    <li>
     <a data-link-type="biblio">[CENC]</a> defines the following terms:
@@ -2714,6 +2769,12 @@ Quantity:   Zero or more.
    <b><a href="#bit_depth">#bit_depth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bit_depth">2.4.4. Semantics</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="chroma_sample_position">
+   <b><a href="#chroma_sample_position">#chroma_sample_position</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-chroma_sample_position">2.4.4. Semantics</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="av1-sample">

--- a/index.html
+++ b/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 0e8880531a1904b4bc0b037759fa3cb386293992" name="generator">
   <link href="https://AOMediaCodec.github.io/av1-isobmff" rel="canonical">
-  <meta content="9a9dedba39b1a2b960572a5fdfe6b5d19cd01919" name="document-revision">
+  <meta content="c2f164deb29f674b4512c2428171413259dcad57" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1573,7 +1573,7 @@ aligned (8) class AV1CodecConfigurationRecord {
   if (initial_presentation_delay_present) {
     unsigned int (4) initial_presentation_delay_minus_one;
   } else {
-    unsigned int (4) reserved;
+    unsigned int (4) reserved = 0;
   }
   unsigned int (1) sequence_parameters_present;
   if (sequence_parameters_present) {

--- a/index.html
+++ b/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 0e8880531a1904b4bc0b037759fa3cb386293992" name="generator">
   <link href="https://AOMediaCodec.github.io/av1-isobmff" rel="canonical">
-  <meta content="6bb5bd7fcd336b194c2fd5812733e01f5b79dad8" name="document-revision">
+  <meta content="9a9dedba39b1a2b960572a5fdfe6b5d19cd01919" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1545,7 +1545,7 @@ Quantity:          One or more.
    <h4 class="heading settled" data-level="2.3.4" id="av1sampleentry-semantics"><span class="secno">2.3.4. </span><span class="content">Semantics</span><a class="self-link" href="#av1sampleentry-semantics"></a></h4>
    <p>The <dfn data-dfn-type="dfn" data-noexport="" id="width">width<a class="self-link" href="#width"></a></dfn> and <dfn data-dfn-type="dfn" data-noexport="" id="height">height<a class="self-link" href="#height"></a></dfn> fields of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-">VisualSampleEntry</a> SHALL equal the values of <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2④">max_frame_width_minus_1</a> + 1 and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑤">max_frame_height_minus_1</a> + 1 of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41">Sequence Header OBU</a> applying to the samples associated with this sample entry.</p>
    <p>The width and height in the TrackHeaderBox SHOULD equal the maximum RenderWidth and RenderHeight values of all the frames associated with this sample entry, respectively called MaxRenderWidth and MaxRenderHeight. Additionally, if MaxRenderWidth and MaxRenderHeight values do not equal respectively the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑥">max_frame_width_minus_1</a> + 1 and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑦">max_frame_height_minus_1</a> + 1 values of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①">Sequence Header OBU</a>, a PixelAspectRatioBox box SHALL be present in the sample entry and set such that</p>
-<pre>hSpacing / vSpacing = MaxRenderWidth * (max_frame_height_minus_1 + 1)/
+<pre>hSpacing / vSpacing = MaxRenderWidth * (max_frame_height_minus_1 + 1) /
                               ((max_frame_width_minus_1 + 1) * MaxRenderHeight)
 </pre>
    <p>The <dfn data-dfn-type="dfn" data-noexport="" id="compressorname">compressorname<a class="self-link" href="#compressorname"></a></dfn> field of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①">VisualSampleEntry</a> is an informative name. It is formatted in a fixed 32-byte field, with the first byte set to the number of bytes to be displayed, followed by that number of bytes of displayable data, followed by padding to complete 32 bytes total (including the size byte). The value "\012AOM Coding" is RECOMMENDED; the first byte is a count of the remaining bytes, here represented by \012, which (being octal 12) is decimal 10, the number of bytes in the rest of the string.</p>
@@ -1563,11 +1563,18 @@ Quantity:  Exactly One
    <h4 class="heading settled" data-level="2.4.2" id="av1codecconfigurationbox-description"><span class="secno">2.4.2. </span><span class="content">Description</span><a class="self-link" href="#av1codecconfigurationbox-description"></a></h4>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1codecconfigurationbox">AV1CodecConfigurationBox</dfn> contains decoder configuration information that SHALL be valid for every sample that references the sample entry.</p>
    <h4 class="heading settled" data-level="2.4.3" id="av1codecconfigurationbox-syntax"><span class="secno">2.4.3. </span><span class="content">Syntax</span><a class="self-link" href="#av1codecconfigurationbox-syntax"></a></h4>
-<pre>class AV1CodecConfigurationBox extends FullBox('av1C', version = 0, 0){
+<pre>class AV1CodecConfigurationBox extends FullBox('av1C', version = 1, 0){
   AV1CodecConfigurationRecord av1Config;
 }
 
 aligned (8) class AV1CodecConfigurationRecord {
+  unsigned int (5) reserved = 0;
+  unsigned int (1) initial_presentation_delay_present;
+  if (initial_presentation_delay_present) {
+    unsigned int (4) initial_presentation_delay_minus_one;
+  } else {
+    unsigned int (4) reserved;
+  }
   unsigned int (1) sequence_parameters_present;
   if (sequence_parameters_present) {
     unsigned int (3) seq_profile;
@@ -1575,9 +1582,8 @@ aligned (8) class AV1CodecConfigurationRecord {
     unsigned int (5) seq_level_idx_0;
     unsigned int (1) seq_tier_0;
     unsigned int (4) bit_depth;
-    unsigned int (1) monochrome;
   } else {
-    unsigned int (15) reserved;
+    unsigned int (14) reserved = 0;
   }
   unsigned int (8)[] configOBUs;
 }
@@ -1592,23 +1598,35 @@ aligned (8) class AV1CodecConfigurationRecord {
    </ul>
    <p class="note" role="note"><span>NOTE:</span> The configOBUs field is expected to contain only OBU_SEQUENCE_HEADER and OBU_METADATA when the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47">metadata OBU</a> is applicable to all the associated samples.</p>
    <p>OBUs stored in the configOBUs field follow the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑧">open_bitstream_unit</a> <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39①">Low Overhead Bitstream Format</a> syntax as specified in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>. The flag <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑨">obu_has_size_field</a> SHALL be set to 1, indicating that the size of the OBU payload follows the header, and that it is coded using LEB128.</p>
-   <p>The <dfn data-dfn-type="dfn" data-export="" id="sequence_parameters_present">sequence_parameters_present<a class="self-link" href="#sequence_parameters_present"></a></dfn> field indicates the presence of the parameters <a data-link-type="dfn" href="#seq_profile" id="ref-for-seq_profile">seq_profile</a>, <a data-link-type="dfn" href="#still_picture" id="ref-for-still_picture">still_picture</a>, <a data-link-type="dfn" href="#seq_level_idx_0" id="ref-for-seq_level_idx_0">seq_level_idx_0</a>, <a data-link-type="dfn" href="#seq_tier_0" id="ref-for-seq_tier_0">seq_tier_0</a>, <a data-link-type="dfn" href="#bit_depth" id="ref-for-bit_depth">bit_depth</a>, and <a data-link-type="dfn" href="#monochrome" id="ref-for-monochrome">monochrome</a> fields from the AV1 <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②">Sequence Header OBU</a>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="initial_presentation_delay_present">initial_presentation_delay_present</dfn> field indicates the presence of the initial_presentation_delay_minus_one field.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</dfn> field indicates the number of samples (minus one) that need be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⓪">seq_level_idx</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②">Sequence Header OBU</a> (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:</p>
    <ul>
     <li data-md="">
-     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="seq_profile">seq_profile</dfn> indicates the AV1 profile and SHALL be equal to the seq_profile value from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41③">Sequence Header OBU</a>.</p>
+     <p>construct a hypothetical bitstream consisting of the OBUs carried in the sample entry followed by the OBUs carried in all the samples,</p>
     <li data-md="">
-     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="still_picture">still_picture</dfn> indicates the value of the still_picture field found in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41④">Sequence Header OBU</a> and SHALL be equal to the value from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑤">Sequence Header OBU</a>.</p>
+     <p>set the first <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①①">initial_display_delay_minus_1</a> field of each <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41③">Sequence Header OBU</a> to the number of frames contained in the first <a data-link-type="dfn" href="#initial_presentation_delay_minus_one" id="ref-for-initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</a> + 1 samples,</p>
     <li data-md="">
-     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="seq_level_idx_0">seq_level_idx_0</dfn> indicates the value of seq_level_idx[0] found in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑥">Sequence Header OBU</a> and SHALL be equal to the value of seq_level_idx[0] in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑦">Sequence Header OBU</a>.</p>
+     <p>set the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①②">frame_presentation_time</a> field of the frame header of each presentable frame such that it matches the presentation time difference between the sample carrying this frame and the previous sample (if it exists, 0 otherwise),</p>
     <li data-md="">
-     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="seq_tier_0">seq_tier_0</dfn> indicates the value of seq_tier[0] found in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑧">Sequence Header OBU</a> and SHALL be equal to the value of seq_tier[0] in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑨">Sequence Header OBU</a>.</p>
+     <p>apply the display model verification algorithm.</p>
+   </ul>
+   <p>When smooth presentation can be guaranteed after decoding the first sample, the value 0 SHALL be used. If an ISOBMFF writer cannot verify the above procedure, <a data-link-type="dfn" href="#initial_presentation_delay_present" id="ref-for-initial_presentation_delay_present">initial_presentation_delay_present</a> SHALL be set to 0.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="sequence_parameters_present">sequence_parameters_present</dfn> field indicates the presence of the parameters <a data-link-type="dfn" href="#seq_profile" id="ref-for-seq_profile">seq_profile</a>, <a data-link-type="dfn" href="#still_picture" id="ref-for-still_picture">still_picture</a>, <a data-link-type="dfn" href="#seq_level_idx_0" id="ref-for-seq_level_idx_0">seq_level_idx_0</a>, <a data-link-type="dfn" href="#seq_tier_0" id="ref-for-seq_tier_0">seq_tier_0</a>, and <a data-link-type="dfn" href="#bit_depth" id="ref-for-bit_depth">bit_depth</a> fields from the AV1 <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41④">Sequence Header OBU</a>.</p>
+   <ul>
+    <li data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="seq_profile">seq_profile</dfn> indicates the AV1 profile and SHALL be equal to the seq_profile value from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑤">Sequence Header OBU</a>.</p>
+    <li data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="still_picture">still_picture</dfn> indicates the value of the still_picture field found in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑥">Sequence Header OBU</a> and SHALL be equal to the value from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑦">Sequence Header OBU</a>.</p>
+    <li data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="seq_level_idx_0">seq_level_idx_0</dfn> indicates the value of seq_level_idx[0] found in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑧">Sequence Header OBU</a> and SHALL be equal to the value of seq_level_idx[0] in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑨">Sequence Header OBU</a>.</p>
+    <li data-md="">
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="seq_tier_0">seq_tier_0</dfn> indicates the value of seq_tier[0] found in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⓪">Sequence Header OBU</a> and SHALL be equal to the value of seq_tier[0] in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①①">Sequence Header OBU</a>.</p>
     <li data-md="">
      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="bit_depth">bit_depth</dfn> indicates the bit depth of pixel components within the output samples from the AV1 bitstream. The value MUST be 8, 10, or 12.</p>
-    <li data-md="">
-     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="monochrome">monochrome</dfn> indicates the value of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⓪">mono_chrome</a> flag from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⓪">Sequence Header OBU</a>.</p>
    </ul>
-   <p>The presentation times of AV1 samples are given by the ISOBMFF structures. The <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①①">timing_info_present_flag</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①①">Sequence Header OBU</a> (in the configOBUs field or in the associated samples) SHOULD be set to 0. If set to 1, the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=45" id="ref-for-page=45">timing_info</a> structure of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①②">Sequence Header OBU</a>, the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①②">frame_presentation_time</a> and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①③">buffer_removal_time</a> fields of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49">Frame Header OBUs</a>, if present, SHALL be ignored for the purpose of timed processing of the ISOBMFF file.</p>
-   <p>If a <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-③">colr</a> box is present in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④">VisualSampleEntry</a> with a colour_type set to <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑤">nclx</a>, the values of colour_primaries, transfer_characteristics, and matrix_coefficients SHALL match the values given in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①③">Sequence Header OBU</a> (in the configOBUs field or in the associated samples) if the color_description_present_flag is set to 1. Similarly, the full_range_flag in the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑥">colr</a> box shall match the color_range flag in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①④">Sequence Header OBU</a>.</p>
+   <p>When the AV1CodecConfigurationRecord indicates that fields from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①②">Sequence Header OBU</a> are present via <a data-link-type="dfn" href="#sequence_parameters_present" id="ref-for-sequence_parameters_present">sequence_parameters_present</a>, and a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①③">Sequence Header OBU</a> is present within the configOBUs, the values present in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①④">Sequence Header OBU</a> contained within configOBUs SHALL match the values of the AV1CodecConfigurationRecord sequence parameters.</p>
+   <p>The presentation times of AV1 samples are given by the ISOBMFF structures. The <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①③">timing_info_present_flag</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑤">Sequence Header OBU</a> (in the configOBUs field or in the associated samples) SHOULD be set to 0. If set to 1, the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=45" id="ref-for-page=45">timing_info</a> structure of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑥">Sequence Header OBU</a>, the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①④">frame_presentation_time</a> and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑤">buffer_removal_time</a> fields of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49">Frame Header OBUs</a>, if present, SHALL be ignored for the purpose of timed processing of the ISOBMFF file.</p>
+   <p>If a <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-③">colr</a> box is present in the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-④">VisualSampleEntry</a> with a colour_type set to <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑤">nclx</a>, the values of colour_primaries, transfer_characteristics, and matrix_coefficients SHALL match the values given in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑦">Sequence Header OBU</a> (in the configOBUs field or in the associated samples) if the color_description_present_flag is set to 1. Similarly, the full_range_flag in the <a class="property" data-link-type="propdesc" href="http://iso.org/#" id="termref-for-⑥">colr</a> box shall match the color_range flag in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑧">Sequence Header OBU</a>.</p>
    <p>Additional boxes may be provided at the end of the <a data-link-type="dfn" href="http://iso.org/#" id="termref-for-⑦">VisualSampleEntry</a> as permitted by ISOBMFF, that may represent redundant or similar information to the one provided in some OBUs contained in the <a data-link-type="dfn" href="#av1codecconfigurationbox" id="ref-for-av1codecconfigurationbox⑤">AV1CodecConfigurationBox</a>. If the box definition does not indicate that its information overrides the OBU information, in case of conflict, the OBU information should be considered authoritative.</p>
    <h3 class="heading settled" data-level="2.5" id="sampleformat"><span class="secno">2.5. </span><span class="content">AV1 Sample Format</span><a class="self-link" href="#sampleformat"></a></h3>
    <p>For tracks using the <a data-link-type="dfn" href="#av1sampleentry" id="ref-for-av1sampleentry②">AV1SampleEntry</a>, an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1-sample">AV1 Sample</dfn> has the following constraints:</p>
@@ -1616,9 +1634,9 @@ aligned (8) class AV1CodecConfigurationRecord {
     <li data-md="">
      <p>the sample data SHALL be a sequence of <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39②">OBUs</a> forming a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑤">Temporal Unit</a>,</p>
     <li data-md="">
-     <p>each OBU SHALL follow the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①④">open_bitstream_unit</a> <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39③">Low Overhead Bitstream Format</a> syntax as specified in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>. Each OBU SHALL have the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑤">obu_has_size_field</a> set to 1 except for the last OBU in the sample, for which <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑥">obu_has_size_field</a> MAY be set to 0, in which case it is assumed to fill the remainder of the sample,</p>
+     <p>each OBU SHALL follow the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑥">open_bitstream_unit</a> <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39③">Low Overhead Bitstream Format</a> syntax as specified in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>. Each OBU SHALL have the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑦">obu_has_size_field</a> set to 1 except for the last OBU in the sample, for which <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑧">obu_has_size_field</a> MAY be set to 0, in which case it is assumed to fill the remainder of the sample,</p>
    </ul>
-   <p class="note" role="note"><span>NOTE:</span> When extracting OBUs from an ISOBMFF file, and depending on the capabilities of the decoder processing these OBUs, ISOBMFF parsers MAY need to either: set the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑦">obu_has_size_field</a> to 1 for some OBUs if not already set, add the size field in this case, and add <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46">Temporal Delimiter OBU</a>; or use the length-delimited bitstream format as defined in Annex B of <a data-link-type="dfn" href="#av1s" id="ref-for-av1s">AV1</a>. If encryption is used, similar operations MAY have to be done before or after decryption depending on the demuxer/decryptor/decoder architecture.</p>
+   <p class="note" role="note"><span>NOTE:</span> When extracting OBUs from an ISOBMFF file, and depending on the capabilities of the decoder processing these OBUs, ISOBMFF parsers MAY need to either: set the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑨">obu_has_size_field</a> to 1 for some OBUs if not already set, add the size field in this case, and add <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46">Temporal Delimiter OBU</a>; or use the length-delimited bitstream format as defined in Annex B of <a data-link-type="dfn" href="#av1s" id="ref-for-av1s">AV1</a>. If encryption is used, similar operations MAY have to be done before or after decryption depending on the demuxer/decryptor/decoder architecture.</p>
    <ul>
     <li data-md="">
      <p>OBU trailing bits SHOULD be limited to byte alignment and SHOULD not be used for padding,</p>
@@ -1628,12 +1646,12 @@ aligned (8) class AV1CodecConfigurationRecord {
    <p>If an AV1 Sample is signaled as a sync sample (in the SyncSampleBox or by setting sample_is_non_sync_sample to 0), it SHALL be a Random Access Point as defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>, i.e. satisfy the following constraints:</p>
    <ul>
     <li data-md="">
-     <p>Its first frame is a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑥">Key Frame</a> that has <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑧">show_frame</a> flag set to 1,</p>
+     <p>Its first frame is a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑥">Key Frame</a> that has <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⓪">show_frame</a> flag set to 1,</p>
     <li data-md="">
-     <p>It contains a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑤">Sequence Header OBU</a> before the first <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49①">Frame Header OBU</a>.</p>
+     <p>It contains a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑨">Sequence Header OBU</a> before the first <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49①">Frame Header OBU</a>.</p>
    </ul>
    <p class="note" role="note"><span>NOTE:</span> Within this definition, a sync sample may contain additional frames that are not Key Frames. The fact that none of them is the first frame in the temporal unit ensures that they are decodable.</p>
-   <p class="note" role="note"><span>NOTE:</span> Other types of OBUs such as <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47①">metadata OBUs</a> could be present before the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑥">Sequence Header OBU</a>.</p>
+   <p class="note" role="note"><span>NOTE:</span> Other types of OBUs such as <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47①">metadata OBUs</a> could be present before the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②⓪">Sequence Header OBU</a>.</p>
    <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑦">Intra-only frames</a> SHOULD be signaled using the sample_depends_on flag set to 2.</p>
    <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑦">Delayed Random Access Points</a> SHOULD be signaled using sample groups and the <a data-link-type="dfn" href="#av1forwardkeyframesamplegroupentry" id="ref-for-av1forwardkeyframesamplegroupentry①">AV1ForwardKeyFrameSampleGroupEntry</a>.</p>
    <p><a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑧">Switch Frames</a> SHOULD be signaled using sample groups and the <a data-link-type="dfn" href="#av1switchframesamplegroupentry" id="ref-for-av1switchframesamplegroupentry">AV1SwitchFrameSampleGroupEntry</a>.</p>
@@ -1773,8 +1791,8 @@ Quantity:   Zero or more.
    <p>When the protected scheme <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①③">cenc</a></code> or <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①④">cbc1</a></code> is used, samples SHALL be protected using subsample encryption and SHALL NOT use pattern encryption.</p>
    <p>When the protected scheme <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑤">cens</a></code> or <code><a data-link-type="dfn" href="http://iso.org/#" id="termref-for-①⑥">cbcs</a></code> is used, samples SHALL be protected using subsample encryption and SHALL use pattern encryption.</p>
    <h3 class="heading settled" data-level="4.1" id="subsample-encryption"><span class="secno">4.1. </span><span class="content">General Subsample Encryption constraints</span><a class="self-link" href="#subsample-encryption"></a></h3>
-   <p>When encrypting <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39④">OBUs</a>, all <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40">OBU Headers</a> and associated <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②①">obu_size</a> fields SHALL be unencrypted. Additionally, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46">Temporal Delimiter OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⓪">Sequence Header OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47⑥">Metadata OBUs</a> (except for those requiring protection), <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49②">Frame Header OBUs</a> SHALL be unencrypted.</p>
-   <p>Within encrypted samples, all <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40①">OBU Headers</a> and associated <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②②">obu_size</a> fields SHALL be unencrypted. Additionally, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46①">Temporal Delimiter OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①①">Sequence Header OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47⑦">Metadata OBUs</a> (except for those requiring protection), <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49③">Frame Header OBUs</a> (including with a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71">Frame OBU</a>) SHALL be unencrypted. <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=72" id="ref-for-page=72">Tile Group OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71①">Frame OBUs</a> (except the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49④">Frame Header OBU</a> part) and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=121" id="ref-for-page=121">Tile List OBUs</a> MAY be encrypted. This is illustrated in Figure #1 and Figure #2, where for simplicity the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②③">obu_size</a> field is assumed to be part of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40②">OBU Header</a>.</p>
+   <p>When encrypting <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39④">OBUs</a>, all <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40">OBU Headers</a> and associated <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑨">obu_size</a> fields SHALL be unencrypted. Additionally, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46①">Temporal Delimiter OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑦">Sequence Header OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47⑥">Metadata OBUs</a> (except for those requiring protection), <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49②">Frame Header OBUs</a> SHALL be unencrypted.</p>
+   <p>Within encrypted samples, all <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40①">OBU Headers</a> and associated <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⓪">obu_size</a> fields SHALL be unencrypted. Additionally, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46②">Temporal Delimiter OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑧">Sequence Header OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=47" id="ref-for-page=47⑦">Metadata OBUs</a> (except for those requiring protection), <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49③">Frame Header OBUs</a> (including with a <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71">Frame OBU</a>) SHALL be unencrypted. <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=72" id="ref-for-page=72">Tile Group OBUs</a>, <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71①">Frame OBUs</a> (except the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49④">Frame Header OBU</a> part) and <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=121" id="ref-for-page=121">Tile List OBUs</a> MAY be encrypted. This is illustrated in Figure #1 and Figure #2, where for simplicity the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②①">obu_size</a> field is assumed to be part of the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40②">OBU Header</a>.</p>
     <li data-md="">
      <p>Protected samples SHALL be exactly spanned by one or more contiguous subsamples.</p>
     <li data-md="">
@@ -1816,13 +1834,13 @@ Quantity:   Zero or more.
 &lt;colorPrimaries>.&lt;transferCharacteristics>.&lt;matrixCoefficients>.&lt;videoFullRangeFlag>
 </pre>
    <p>All fields following the sample entry 4CC are expressed as double digit decimals, unless indicated otherwise. Leading or trailing zeros cannot be omitted.</p>
-   <p>The profile parameter value, represented by a single digit decimal, SHALL equal the value of seq_profile in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①②">Sequence Header OBU</a>.</p>
-   <p>The level parameter value SHALL equal the first level value indicated by <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⑥">seq_level_idx</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①③">Sequence Header OBU</a>.</p>
-   <p>The tier parameter value SHALL be equal to <code>M</code> when the first <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⑦">seq_tier</a> value in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①④">Sequence Header OBU</a> is equal to 0, and <code>H</code> when it is equal to 1.</p>
-   <p>The bitDepth parameter value SHALL equal the value of BitDepth variable as defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> derived from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑤">Sequence Header OBU</a>.</p>
-   <p>The monochrome parameter value, represented by a single digit decimal, SHALL equal the value of mono_chrome in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑥">Sequence Header OBU</a>.</p>
+   <p>The profile parameter value, represented by a single digit decimal, SHALL equal the value of seq_profile in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑨">Sequence Header OBU</a>.</p>
+   <p>The level parameter value SHALL equal the first level value indicated by <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②④">seq_level_idx</a> in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②⓪">Sequence Header OBU</a>.</p>
+   <p>The tier parameter value SHALL be equal to <code>M</code> when the first <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⑤">seq_tier</a> value in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②①">Sequence Header OBU</a> is equal to 0, and <code>H</code> when it is equal to 1.</p>
+   <p>The bitDepth parameter value SHALL equal the value of BitDepth variable as defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> derived from the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②②">Sequence Header OBU</a>.</p>
+   <p>The monochrome parameter value, represented by a single digit decimal, SHALL equal the value of mono_chrome in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②③">Sequence Header OBU</a>.</p>
    <p>The chromaSubsampling parameter value, represented by a three-digit decimal, SHALL have its first digit equal to subsampling_x and its second digit equal to subsampling_y. If both subsampling_x and subsampling_y are set to 1, then the third digit SHALL be equal to chroma_sample_position, otherwise it SHALL be set to 0.</p>
-   <p>The colorPrimaries, transferCharacteristics, matrixCoefficients and videoFullRangeFlag parameter values SHALL equal the value of matching fields in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑦">Sequence Header OBU</a>, if color_description_present_flag is set to 1, otherwise they SHOULD not be set, defaulting to the values below. The videoFullRangeFlag is represented by a single digit.</p>
+   <p>The colorPrimaries, transferCharacteristics, matrixCoefficients and videoFullRangeFlag parameter values SHALL equal the value of matching fields in the <a data-link-type="dfn" href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②④">Sequence Header OBU</a>, if color_description_present_flag is set to 1, otherwise they SHOULD not be set, defaulting to the values below. The videoFullRangeFlag is represented by a single digit.</p>
    <p>For example, codecs="av01.0.04M.10.0.112.09.16.09.0" represents AV1 profile 0, level 3.0, Main tier, 10-bit content, non-monochrome, with 4:2:0 chroma subsampling, ITU-R BT.2100 color primaries, ITU BT.2100 PQ transfer characteristics, ITU-R BT.2100 YCbCr color matrix, and studio swing representation.</p>
    <p>The parameters sample entry 4CC, profile, level, tier, and bitDepth are all mandatory fields. If any of these fields are empty, or not within their allowed range, the processing device SHOULD treat it as an error.</p>
    <p>All the other fields (including their leading '.') are optional, mutually inclusive (all or none) fields. If not specified then the values listed in the table below are assumed.</p>
@@ -2024,8 +2042,9 @@ Quantity:   Zero or more.
    <li><a href="#configobus">configOBUs</a><span>, in §2.4.4</span>
    <li><a href="#fwd_distance">fwd_distance</a><span>, in §2.6.4</span>
    <li><a href="#height">height</a><span>, in §2.3.4</span>
+   <li><a href="#initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</a><span>, in §2.4.4</span>
+   <li><a href="#initial_presentation_delay_present">initial_presentation_delay_present</a><span>, in §2.4.4</span>
    <li><a href="#metadata_type">metadata_type</a><span>, in §2.9.4</span>
-   <li><a href="#monochrome">monochrome</a><span>, in §2.4.4</span>
    <li><a href="#seq_level_idx_0">seq_level_idx_0</a><span>, in §2.4.4</span>
    <li><a href="#seq_profile">seq_profile</a><span>, in §2.4.4</span>
    <li><a href="#seq_tier_0">seq_tier_0</a><span>, in §2.4.4</span>
@@ -2045,8 +2064,8 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
-    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
+    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
     <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
@@ -2084,11 +2103,20 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
+    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
     <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
-    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-page=2">
+   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
+    <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
+    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
     <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
@@ -2140,8 +2168,8 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
-    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
+    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
     <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
@@ -2152,8 +2180,8 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
-    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
+    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
     <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
@@ -2167,17 +2195,6 @@ Quantity:   Zero or more.
     <li><a href="#ref-for-page=47④">2.9.2. Description</a>
     <li><a href="#ref-for-page=47⑤">3. CMAF AV1 track format and CMAF media profiles</a>
     <li><a href="#ref-for-page=47⑥">4.1. General Subsample Encryption constraints</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-page=2">
-   <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
-    <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
-    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
-    <li><a href="#ref-for-page=2①⑨">4.1. Sample Encryption</a> <a href="#ref-for-page=2②⓪">(2)</a> <a href="#ref-for-page=2②①">(3)</a> <a href="#ref-for-page=2②②">(4)</a> <a href="#ref-for-page=2②③">(5)</a>
-    <li><a href="#ref-for-page=2②④">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=39">
@@ -2200,8 +2217,8 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
-    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
+    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
     <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
@@ -2212,8 +2229,8 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
-    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
+    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
     <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
@@ -2224,8 +2241,8 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
-    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
+    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
     <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
@@ -2245,8 +2262,8 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
-    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
+    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
     <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
@@ -2257,8 +2274,8 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
-    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
+    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
     <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
@@ -2268,10 +2285,10 @@ Quantity:   Zero or more.
    <a href="http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41">http://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page=41">2.3.4. Semantics</a> <a href="#ref-for-page=41①">(2)</a>
-    <li><a href="#ref-for-page=41②">2.4.4. Semantics</a> <a href="#ref-for-page=41③">(2)</a> <a href="#ref-for-page=41④">(3)</a> <a href="#ref-for-page=41⑤">(4)</a> <a href="#ref-for-page=41⑥">(5)</a> <a href="#ref-for-page=41⑦">(6)</a> <a href="#ref-for-page=41⑧">(7)</a> <a href="#ref-for-page=41⑨">(8)</a> <a href="#ref-for-page=41①⓪">(9)</a> <a href="#ref-for-page=41①①">(10)</a> <a href="#ref-for-page=41①②">(11)</a> <a href="#ref-for-page=41①③">(12)</a> <a href="#ref-for-page=41①④">(13)</a>
-    <li><a href="#ref-for-page=41①⑤">2.5. AV1 Sample Format</a> <a href="#ref-for-page=41①⑥">(2)</a>
-    <li><a href="#ref-for-page=41①⓪">4.1. Sample Encryption</a> <a href="#ref-for-page=41①①">(2)</a>
-    <li><a href="#ref-for-page=41①②">5. Codecs Parameter String</a> <a href="#ref-for-page=41①③">(2)</a> <a href="#ref-for-page=41①④">(3)</a> <a href="#ref-for-page=41①⑤">(4)</a> <a href="#ref-for-page=41①⑥">(5)</a> <a href="#ref-for-page=41①⑦">(6)</a>
+    <li><a href="#ref-for-page=41②">2.4.4. Semantics</a> <a href="#ref-for-page=41③">(2)</a> <a href="#ref-for-page=41④">(3)</a> <a href="#ref-for-page=41⑤">(4)</a> <a href="#ref-for-page=41⑥">(5)</a> <a href="#ref-for-page=41⑦">(6)</a> <a href="#ref-for-page=41⑧">(7)</a> <a href="#ref-for-page=41⑨">(8)</a> <a href="#ref-for-page=41①⓪">(9)</a> <a href="#ref-for-page=41①①">(10)</a> <a href="#ref-for-page=41①②">(11)</a> <a href="#ref-for-page=41①③">(12)</a> <a href="#ref-for-page=41①④">(13)</a> <a href="#ref-for-page=41①⑤">(14)</a> <a href="#ref-for-page=41①⑥">(15)</a> <a href="#ref-for-page=41①⑦">(16)</a> <a href="#ref-for-page=41①⑧">(17)</a>
+    <li><a href="#ref-for-page=41①⑨">2.5. AV1 Sample Format</a> <a href="#ref-for-page=41②⓪">(2)</a>
+    <li><a href="#ref-for-page=41①⑦">4.1. Sample Encryption</a> <a href="#ref-for-page=41①⑧">(2)</a>
+    <li><a href="#ref-for-page=41①⑨">5. Codecs Parameter String</a> <a href="#ref-for-page=41②⓪">(2)</a> <a href="#ref-for-page=41②①">(3)</a> <a href="#ref-for-page=41②②">(4)</a> <a href="#ref-for-page=41②③">(5)</a> <a href="#ref-for-page=41②④">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-page=2">
@@ -2279,8 +2296,8 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
-    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
+    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
     <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
@@ -2291,8 +2308,8 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
-    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
+    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
     <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
@@ -2344,8 +2361,8 @@ Quantity:   Zero or more.
    <ul>
     <li><a href="#ref-for-page=2">1. Bitstream features overview</a> <a href="#ref-for-page=2①">(2)</a> <a href="#ref-for-page=2②">(3)</a> <a href="#ref-for-page=2③">(4)</a>
     <li><a href="#ref-for-page=2④">2.3.4. Semantics</a> <a href="#ref-for-page=2⑤">(2)</a> <a href="#ref-for-page=2⑥">(3)</a> <a href="#ref-for-page=2⑦">(4)</a>
-    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a>
-    <li><a href="#ref-for-page=2①④">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑤">(2)</a> <a href="#ref-for-page=2①⑥">(3)</a> <a href="#ref-for-page=2①⑦">(4)</a> <a href="#ref-for-page=2①⑧">(5)</a>
+    <li><a href="#ref-for-page=2⑧">2.4.4. Semantics</a> <a href="#ref-for-page=2⑨">(2)</a> <a href="#ref-for-page=2①⓪">(3)</a> <a href="#ref-for-page=2①①">(4)</a> <a href="#ref-for-page=2①②">(5)</a> <a href="#ref-for-page=2①③">(6)</a> <a href="#ref-for-page=2①④">(7)</a> <a href="#ref-for-page=2①⑤">(8)</a>
+    <li><a href="#ref-for-page=2①⑥">2.5. AV1 Sample Format</a> <a href="#ref-for-page=2①⑦">(2)</a> <a href="#ref-for-page=2①⑧">(3)</a> <a href="#ref-for-page=2①⑨">(4)</a> <a href="#ref-for-page=2②⓪">(5)</a>
     <li><a href="#ref-for-page=2②①">4.1. Sample Encryption</a> <a href="#ref-for-page=2②②">(2)</a> <a href="#ref-for-page=2②③">(3)</a> <a href="#ref-for-page=2②④">(4)</a> <a href="#ref-for-page=2②⑤">(5)</a>
     <li><a href="#ref-for-page=2②②">4.4. Illustration</a>
     <li><a href="#ref-for-page=2②⑥">5. Codecs Parameter String</a> <a href="#ref-for-page=2②⑦">(2)</a>
@@ -2564,10 +2581,9 @@ Quantity:   Zero or more.
      <li><span class="dfn-paneled" id="term-for-page=13②" style="color:initial">key frame</span>
      <li><span class="dfn-paneled" id="term-for-page=206①" style="color:initial">key frame dependent recovery point</span>
      <li><span class="dfn-paneled" id="term-for-page=39" style="color:initial">low overhead bitstream format</span>
-     <li><span class="dfn-paneled" id="term-for-page=2③" style="color:initial">max_frame_height_minus_1</span>
-     <li><span class="dfn-paneled" id="term-for-page=2④" style="color:initial">max_frame_width_minus_1</span>
+     <li><span class="dfn-paneled" id="term-for-page=2④" style="color:initial">max_frame_height_minus_1</span>
+     <li><span class="dfn-paneled" id="term-for-page=2⑤" style="color:initial">max_frame_width_minus_1</span>
      <li><span class="dfn-paneled" id="term-for-page=47" style="color:initial">metadata obu</span>
-     <li><span class="dfn-paneled" id="term-for-page=2⑤" style="color:initial">mono_chrome</span>
      <li><span class="dfn-paneled" id="term-for-page=39①" style="color:initial">obu</span>
      <li><span class="dfn-paneled" id="term-for-page=40" style="color:initial">obu header</span>
      <li><span class="dfn-paneled" id="term-for-page=2⑤" style="color:initial">obu_has_size_field</span>
@@ -2651,6 +2667,24 @@ Quantity:   Zero or more.
     <li><a href="#ref-for-av1codecconfigurationbox③">2.4.4. Semantics</a> <a href="#ref-for-av1codecconfigurationbox④">(2)</a> <a href="#ref-for-av1codecconfigurationbox⑤">(3)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="initial_presentation_delay_present">
+   <b><a href="#initial_presentation_delay_present">#initial_presentation_delay_present</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-initial_presentation_delay_present">2.4.4. Semantics</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="initial_presentation_delay_minus_one">
+   <b><a href="#initial_presentation_delay_minus_one">#initial_presentation_delay_minus_one</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-initial_presentation_delay_minus_one">2.4.4. Semantics</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="sequence_parameters_present">
+   <b><a href="#sequence_parameters_present">#sequence_parameters_present</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-sequence_parameters_present">2.4.4. Semantics</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="seq_profile">
    <b><a href="#seq_profile">#seq_profile</a></b><b>Referenced in:</b>
    <ul>
@@ -2679,12 +2713,6 @@ Quantity:   Zero or more.
    <b><a href="#bit_depth">#bit_depth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bit_depth">2.4.4. Semantics</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="monochrome">
-   <b><a href="#monochrome">#monochrome</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-monochrome">2.4.4. Semantics</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="av1-sample">


### PR DESCRIPTION
    Add the following fields to AV1CodecConfigurationRecord:
    - version  
    - seq_profile
    - still_picture
    - seq_level_idx_0
    - seq_tier_0
    - bit_depth
    - monochrome
    - chroma_subsampling_x
    - chroma_subsampling_y
    - chrome_sample_position
    
    Also, some minor tweaks:
    - Update date.
    - Update AV1 bitstream spec status (LS -> Standard).
    - Add seq_profile, still_picture, mono_chrome to
      subsampling_x, subsampling_y, and 
      chroma_sample_position to terms defined in AV1.