### PR TITLE
Rename initial presentation delay fields.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -261,9 +261,9 @@ aligned (8) class AV1CodecConfigurationRecord {
   unsigned int (2) chroma_sample_position;
   unsigned int (3) reserved = 0;
 
-  unsigned int (1) initial_delay_present;
-  if (initial_delay_present) {
-    unsigned int (4) initial_delay_samples_minus_one;
+  unsigned int (1) initial_display_delay_present;
+  if (initial_display_delay_present) {
+    unsigned int (4) initial_display_delay_in_samples_minus_1;
   } else {
     unsigned int (4) reserved = 0;
   }
@@ -300,20 +300,20 @@ The <dfn export>chroma_sample_position</dfn> field indicates the [=chroma_sample
 
 When not specified in the [=Sequence Header OBU=], and not defined by the conditions specified in the [[!AV1]] [=color_config=], the values of [=chroma_subsampling_x=], [=chroma_subsampling_y=], and [=chroma_sample_position=] SHALL be 0.
 
-The <dfn export>initial_delay_present</dfn> field indicates the presence of the initial_delay_samples_minus_one field.
+The <dfn export>initial_display_delay_present</dfn> field indicates the presence of the initial_display_delay_in_samples_minus_1 field.
 
-The <dfn>initial_delay_samples_minus_one</dfn> field indicates the number of samples (minus one) that need to be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by [=seq_level_idx=] in the [=Sequence Header OBU=] (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:
+The <dfn>initial_display_delay_in_samples_minus_1</dfn> field indicates the number of samples (minus one) that need to be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by [=seq_level_idx=] in the [=Sequence Header OBU=] (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:
 - construct a hypothetical bitstream consisting of the OBUs carried in the sample entry followed by the OBUs carried in all the samples referring to that sample entry,
-- set the first [=initial_display_delay_minus_1=] field of each [=Sequence Header OBU=] to the number of frames minus one contained in the first [=initial_delay_samples_minus_one=] + 1 samples,
+- set the first [=initial_display_delay_minus_1=] field of each [=Sequence Header OBU=] to the number of frames minus one contained in the first [=initial_display_delay_in_samples_minus_1=] + 1 samples,
 - set the [=frame_presentation_time=] field of the frame header of each presentable frame such that it matches the presentation time difference between the sample carrying this frame and the previous sample (if it exists, 0 otherwise),
 - apply the decoder model specified in [[!AV1]] to this hypothetical bitstream using the first operating point. If <code>buffer_removal_time</code> information is present in bitstream for this operating point, the decoding schedule mode SHALL be applied, otherwise the resource availability mode SHALL be applied.
 
-NOTE: With the above procedure, when smooth presentation can be guaranteed after decoding the first sample, initial_delay_samples_minus_one is 0.
+NOTE: With the above procedure, when smooth presentation can be guaranteed after decoding the first sample, initial_display_delay_in_samples_minus_1 is 0.
 
-NOTE: Because the above procedure considers all OBUs in all samples associated with a sample entry, if these OBUS form multiple coded video sequences which would have different values of <code>initial_delay_samples_minus_one</code> if considered separately, the sample entry would signal the larger value.
+NOTE: Because the above procedure considers all OBUs in all samples associated with a sample entry, if these OBUS form multiple coded video sequences which would have different values of <code>initial_display_delay_in_samples_minus_1</code> if considered separately, the sample entry would signal the larger value.
 
 <div class=example>
-The difference between [=initial_delay_samples_minus_one=] and [=initial_display_delay_minus_1=] can be illustrated by considering the following example:
+The difference between [=initial_display_delay_in_samples_minus_1=] and [=initial_display_delay_minus_1=] can be illustrated by considering the following example:
 ```
 a b c d e f g h
 ```
@@ -321,12 +321,12 @@ where letters correspond to frames. Assume that <code>[=initial_display_delay_mi
 ```
 [a] [b c d] [e] [f] [g] [h]
 ```
-<code>[=initial_delay_samples_minus_one=]</code> would be 1 because it takes presentation of 2 samples to ensure that <code>c</code> is decoded.
+<code>[=initial_display_delay_in_samples_minus_1=]</code> would be 1 because it takes presentation of 2 samples to ensure that <code>c</code> is decoded.
 But if the frames were grouped as follows:
 ```
 [a] [b] [c] [d e f] [g] [h]
 ```
-<code>[=initial_delay_samples_minus_one=]</code> would be 2 because it takes presentation of 3 samples to ensure that <code>c</code> is decoded.
+<code>[=initial_display_delay_in_samples_minus_1=]</code> would be 2 because it takes presentation of 3 samples to ensure that <code>c</code> is decoded.
 </div>
 
 The <dfn export>configOBUs</dfn> field contains zero or more OBUs. Any OBU may be present provided that the following procedures produce compliant AV1 bitstreams:
@@ -520,7 +520,7 @@ If a [=CMAF Video Track=] uses the brand <code>av01</code>, it is called a <dfn>
     - the first value of <code>seq_level_idx</code>
     - the first value of <code>seq_tier</code>
     - <code>color_config</code>
-    - <code>initial_delay_samples_minus_one</code>
+    - <code>initial_display_delay_in_samples_minus_1</code>
 
 When protected, [=CMAF AV1 Tracks=] SHALL use the signaling defined in [[!CMAF]], which in turn relies on [[!CENC]], with the provisions specified in [[#CommonEncryption]].
 

--- a/index.bs
+++ b/index.bs
@@ -6,7 +6,7 @@ Shortname: av1-isobmff
 Editor: Cyril Concolato, Netflix, cconcolato@netflix.com
 Editor: Tom Finegan, Google, tom.finegan@google.com
 Abstract: This document specifies the storage format for [[!AV1]] bitstreams in [[!ISOBMFF]] tracks as well as in [[!CMAF]] files.
-Date: 2018-09-11
+Date: 2018-10-10
 Repository: AOMediaCodec/av1-isobmff
 Inline Github Issues: full
 Boilerplate: property-index no, issues-index no, copyright yes
@@ -261,9 +261,9 @@ aligned (8) class AV1CodecConfigurationRecord {
   unsigned int (2) chroma_sample_position;
   unsigned int (3) reserved = 0;
 
-  unsigned int (1) initial_presentation_delay_present;
-  if (initial_presentation_delay_present) {
-    unsigned int (4) initial_presentation_delay_minus_one;
+  unsigned int (1) initial_delay_present;
+  if (initial_delay_present) {
+    unsigned int (4) initial_delay_samples_minus_one;
   } else {
     unsigned int (4) reserved = 0;
   }
@@ -300,20 +300,20 @@ The <dfn export>chroma_sample_position</dfn> field indicates the [=chroma_sample
 
 When not specified in the [=Sequence Header OBU=], and not defined by the conditions specified in the [[!AV1]] [=color_config=], the values of [=chroma_subsampling_x=], [=chroma_subsampling_y=], and [=chroma_sample_position=] SHALL be 0.
 
-The <dfn export>initial_presentation_delay_present</dfn> field indicates the presence of the initial_presentation_delay_minus_one field.
+The <dfn export>initial_delay_present</dfn> field indicates the presence of the initial_delay_samples_minus_one field.
 
-The <dfn>initial_presentation_delay_minus_one</dfn> field indicates the number of samples (minus one) that need to be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by [=seq_level_idx=] in the [=Sequence Header OBU=] (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:
+The <dfn>initial_delay_samples_minus_one</dfn> field indicates the number of samples (minus one) that need to be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by [=seq_level_idx=] in the [=Sequence Header OBU=] (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:
 - construct a hypothetical bitstream consisting of the OBUs carried in the sample entry followed by the OBUs carried in all the samples referring to that sample entry,
-- set the first [=initial_display_delay_minus_1=] field of each [=Sequence Header OBU=] to the number of frames minus one contained in the first [=initial_presentation_delay_minus_one=] + 1 samples,
+- set the first [=initial_display_delay_minus_1=] field of each [=Sequence Header OBU=] to the number of frames minus one contained in the first [=initial_delay_samples_minus_one=] + 1 samples,
 - set the [=frame_presentation_time=] field of the frame header of each presentable frame such that it matches the presentation time difference between the sample carrying this frame and the previous sample (if it exists, 0 otherwise),
 - apply the decoder model specified in [[!AV1]] to this hypothetical bitstream using the first operating point. If <code>buffer_removal_time</code> information is present in bitstream for this operating point, the decoding schedule mode SHALL be applied, otherwise the resource availability mode SHALL be applied.
 
-NOTE: With the above procedure, when smooth presentation can be guaranteed after decoding the first sample, initial_presentation_delay_minus_one is 0.
+NOTE: With the above procedure, when smooth presentation can be guaranteed after decoding the first sample, initial_delay_samples_minus_one is 0.
 
-NOTE: Because the above procedure considers all OBUs in all samples associated with a sample entry, if these OBUS form multiple coded video sequences which would have different values of <code>initial_presentation_delay_minus_one</code> if considered separately, the sample entry would signal the larger value.
+NOTE: Because the above procedure considers all OBUs in all samples associated with a sample entry, if these OBUS form multiple coded video sequences which would have different values of <code>initial_delay_samples_minus_one</code> if considered separately, the sample entry would signal the larger value.
 
 <div class=example>
-The difference between [=initial_presentation_delay_minus_one=] and [=initial_display_delay_minus_1=] can be illustrated by considering the following example:
+The difference between [=initial_delay_samples_minus_one=] and [=initial_display_delay_minus_1=] can be illustrated by considering the following example:
 ```
 a b c d e f g h
 ```
@@ -321,12 +321,12 @@ where letters correspond to frames. Assume that <code>[=initial_display_delay_mi
 ```
 [a] [b c d] [e] [f] [g] [h]
 ```
-<code>[=initial_presentation_delay_minus_one=]</code> would be 1 because it takes presentation of 2 samples to ensure that <code>c</code> is decoded.
+<code>[=initial_delay_samples_minus_one=]</code> would be 1 because it takes presentation of 2 samples to ensure that <code>c</code> is decoded.
 But if the frames were grouped as follows:
 ```
 [a] [b] [c] [d e f] [g] [h]
 ```
-<code>[=initial_presentation_delay_minus_one=]</code> would be 2 because it takes presentation of 3 samples to ensure that <code>c</code> is decoded.
+<code>[=initial_delay_samples_minus_one=]</code> would be 2 because it takes presentation of 3 samples to ensure that <code>c</code> is decoded.
 </div>
 
 The <dfn export>configOBUs</dfn> field contains zero or more OBUs. Any OBU may be present provided that the following procedures produce compliant AV1 bitstreams:
@@ -520,7 +520,7 @@ If a [=CMAF Video Track=] uses the brand <code>av01</code>, it is called a <dfn>
     - the first value of <code>seq_level_idx</code>
     - the first value of <code>seq_tier</code>
     - <code>color_config</code>
-    - <code>initial_presentation_delay_minus_one</code>
+    - <code>initial_delay_samples_minus_one</code>
 
 When protected, [=CMAF AV1 Tracks=] SHALL use the signaling defined in [[!CMAF]], which in turn relies on [[!CENC]], with the provisions specified in [[#CommonEncryption]].
 

--- a/index.html
+++ b/index.html
@@ -1058,10 +1058,9 @@ Possible extra rowspan handling
 			   comprising the first items of each top-level section. */
 			margin-top: 1.1rem;
 		}
-		#toc#toc .secno { /* Ugh, need more specificity to override base.css */
+		#toc .secno {
 			grid-column: 1;
 			width: auto;
-			margin-left: 0;
 		}
 		#toc .content {
 			grid-column: 2;
@@ -1212,9 +1211,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 1ae98debb4e51d3776dd78f95940efb62b6b8e27" name="generator">
+  <meta content="Bikeshed version 0e8880531a1904b4bc0b037759fa3cb386293992" name="generator">
   <link href="https://aomediacodec.github.io/av1-isobmff/" rel="canonical">
-  <meta content="bcac53f04aecdab238c2468261d383dd17f9e998" name="document-revision">
+  <meta content="0a8261dba84de338a1f9ee5e323d8ab5983c2017" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1403,7 +1402,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">AV1 Codec ISO Media File Format Binding</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2018-09-11">11 September 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2018-10-10">10 October 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1418,7 +1417,7 @@ pre .property::before, pre .property::after {
     </dl>
    </div>
    <div data-fill-with="warning">
-    <details class="annoying-warning" open>
+    <details class="annoying-warning" open="">
      <summary>Release Candidate</summary>
      <p>This document is the release candidate for the next version of this specification. It awaits formal approval by the AOM. Once approved, any further change in future versions will be documented and backwards compatible, unless interoperability concerns are uncovered.</p>
     </details>
@@ -1529,54 +1528,54 @@ pre .property::before, pre .property::after {
    <h3 class="heading settled" data-level="2.1" id="brands"><span class="secno">2.1. </span><span class="content">General Requirements &amp; Brands</span><a class="self-link" href="#brands"></a></h3>
    <p>A file conformant to this specification satisfies the following:</p>
    <ul>
-    <li data-md>
+    <li data-md="">
      <p>It SHALL conform to the normative requirements of <a data-link-type="biblio" href="#biblio-isobmff">[ISOBMFF]</a></p>
-    <li data-md>
-     <p>It SHALL have the <dfn class="css" data-dfn-for="ISOBMFF Brand" data-dfn-type="value" data-export id="valdef-isobmff-brand-av01">av01<a class="self-link" href="#valdef-isobmff-brand-av01"></a></dfn> brand among the compatible brands array of the FileTypeBox</p>
-    <li data-md>
+    <li data-md="">
+     <p>It SHALL have the <dfn class="css" data-dfn-for="ISOBMFF Brand" data-dfn-type="value" data-export="" id="valdef-isobmff-brand-av01">av01<a class="self-link" href="#valdef-isobmff-brand-av01"></a></dfn> brand among the compatible brands array of the FileTypeBox</p>
+    <li data-md="">
      <p>It SHALL contain at least one track using an <a data-link-type="dfn" href="#av1sampleentry" id="ref-for-av1sampleentry">AV1SampleEntry</a></p>
-    <li data-md>
+    <li data-md="">
      <p>It SHOULD indicate a structural ISOBMFF brand among the compatible brands array of the FileTypeBox, such as <a class="property" data-link-type="propdesc" href="https://www.iso.org/standard/68960.html#" id="termref-for-">iso6</a></p>
-    <li data-md>
+    <li data-md="">
      <p>It MAY indicate CMAF brands as specified in <a href="#cmaf">§3 CMAF AV1 track format</a></p>
-    <li data-md>
+    <li data-md="">
      <p>It MAY indicate other brands not specified in this document provided that the associated requirements do not conflict with those given in this specification</p>
    </ul>
    <p>Parsers SHALL support the structures required by the <code><a class="property" data-link-type="propdesc" href="https://www.iso.org/standard/68960.html#" id="termref-for-①">iso6</a></code> brand and MAY support structures required by further ISOBMFF structural brands.</p>
    <h3 class="heading settled" data-level="2.2" id="av1sampleentry-section"><span class="secno">2.2. </span><span class="content">AV1 Sample Entry</span><a class="self-link" href="#av1sampleentry-section"></a></h3>
    <h4 class="heading settled" data-level="2.2.1" id="av1sampleentry-definition"><span class="secno">2.2.1. </span><span class="content">Definition</span><a class="self-link" href="#av1sampleentry-definition"></a></h4>
-<pre class="def">Sample Entry Type: <dfn data-dfn-for="AV1SampleEntry" data-dfn-type="value" data-export id="valdef-av1sampleentry-av01">av01<a class="self-link" href="#valdef-av1sampleentry-av01"></a></dfn>
+<pre class="def">Sample Entry Type: <dfn data-dfn-for="AV1SampleEntry" data-dfn-type="value" data-export="" id="valdef-av1sampleentry-av01">av01<a class="self-link" href="#valdef-av1sampleentry-av01"></a></dfn>
 Container:         Sample Description Box ('stsd')
 Mandatory:         Yes
 Quantity:          One or more.
 </pre>
    <h4 class="heading settled" data-level="2.2.2" id="av1sampleentry-description"><span class="secno">2.2.2. </span><span class="content">Description</span><a class="self-link" href="#av1sampleentry-description"></a></h4>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="av1sampleentry">AV1SampleEntry</dfn> sample entry identifies that the track contains <a data-link-type="dfn" href="#av1-sample" id="ref-for-av1-sample">AV1 Samples</a>, and uses an <a data-link-type="dfn" href="#av1codecconfigurationbox" id="ref-for-av1codecconfigurationbox">AV1CodecConfigurationBox</a>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1sampleentry">AV1SampleEntry</dfn> sample entry identifies that the track contains <a data-link-type="dfn" href="#av1-sample" id="ref-for-av1-sample">AV1 Samples</a>, and uses an <a data-link-type="dfn" href="#av1codecconfigurationbox" id="ref-for-av1codecconfigurationbox">AV1CodecConfigurationBox</a>.</p>
    <h4 class="heading settled" data-level="2.2.3" id="av1sampleentry-syntax"><span class="secno">2.2.3. </span><span class="content">Syntax</span><a class="self-link" href="#av1sampleentry-syntax"></a></h4>
 <pre>class AV1SampleEntry extends VisualSampleEntry('av01') {
   AV1CodecConfigurationBox config;
 }
 </pre>
    <h4 class="heading settled" data-level="2.2.4" id="av1sampleentry-semantics"><span class="secno">2.2.4. </span><span class="content">Semantics</span><a class="self-link" href="#av1sampleentry-semantics"></a></h4>
-   <p>The <dfn data-dfn-type="dfn" data-noexport id="width">width<a class="self-link" href="#width"></a></dfn> and <dfn data-dfn-type="dfn" data-noexport id="height">height<a class="self-link" href="#height"></a></dfn> fields of the <a data-link-type="dfn" href="https://www.iso.org/standard/68960.html#" id="termref-for-②">VisualSampleEntry</a> SHALL equal the values of <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2④">max_frame_width_minus_1</a> + 1 and <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑤">max_frame_height_minus_1</a> + 1 of the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41">Sequence Header OBU</a> applying to the samples associated with this sample entry.</p>
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="width">width<a class="self-link" href="#width"></a></dfn> and <dfn data-dfn-type="dfn" data-noexport="" id="height">height<a class="self-link" href="#height"></a></dfn> fields of the <a data-link-type="dfn" href="https://www.iso.org/standard/68960.html#" id="termref-for-②">VisualSampleEntry</a> SHALL equal the values of <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2④">max_frame_width_minus_1</a> + 1 and <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑤">max_frame_height_minus_1</a> + 1 of the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41">Sequence Header OBU</a> applying to the samples associated with this sample entry.</p>
    <p>The width and height in the TrackHeaderBox SHOULD equal, respectively, the maximum RenderWidth, called MaxRenderWidth, and the maximum RenderHeight, called MaxRenderHeight, of all the frames associated with this sample entry. Additionally, if MaxRenderWidth and MaxRenderHeight values do not equal respectively the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑥">max_frame_width_minus_1</a> + 1 and <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑦">max_frame_height_minus_1</a> + 1 values of the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①">Sequence Header OBU</a>, a PixelAspectRatioBox box SHALL be present in the sample entry and set such that</p>
 <pre>hSpacing / vSpacing = MaxRenderWidth * (max_frame_height_minus_1 + 1) /
                               ((max_frame_width_minus_1 + 1) * MaxRenderHeight)
 </pre>
-   <p>The <dfn data-dfn-type="dfn" data-noexport id="compressorname">compressorname<a class="self-link" href="#compressorname"></a></dfn> field of the <a data-link-type="dfn" href="https://www.iso.org/standard/68960.html#" id="termref-for-③">VisualSampleEntry</a> is an informative name. It is formatted in a fixed 32-byte field, with the first byte set to the number of bytes to be displayed, followed by that number of bytes of displayable data, followed by padding to complete 32 bytes total (including the size byte). The value "\012AOM Coding" is RECOMMENDED; the first byte is a count of the remaining bytes, here represented by \012, which (being octal 12) is decimal 10, the number of bytes in the rest of the string.</p>
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="compressorname">compressorname<a class="self-link" href="#compressorname"></a></dfn> field of the <a data-link-type="dfn" href="https://www.iso.org/standard/68960.html#" id="termref-for-③">VisualSampleEntry</a> is an informative name. It is formatted in a fixed 32-byte field, with the first byte set to the number of bytes to be displayed, followed by that number of bytes of displayable data, followed by padding to complete 32 bytes total (including the size byte). The value "\012AOM Coding" is RECOMMENDED; the first byte is a count of the remaining bytes, here represented by \012, which (being octal 12) is decimal 10, the number of bytes in the rest of the string.</p>
    <p class="note" role="note"><span>NOTE:</span> Parsers may ignore the value of the compressorname field. It is specified in this document simply for legacy and backwards compatibility reasons.</p>
-   <p>The <dfn data-dfn-type="dfn" data-noexport id="config">config<a class="self-link" href="#config"></a></dfn> field SHALL contain an <a data-link-type="dfn" href="#av1codecconfigurationbox" id="ref-for-av1codecconfigurationbox①">AV1CodecConfigurationBox</a> that applies to the samples associated with this sample entry.</p>
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="config">config<a class="self-link" href="#config"></a></dfn> field SHALL contain an <a data-link-type="dfn" href="#av1codecconfigurationbox" id="ref-for-av1codecconfigurationbox①">AV1CodecConfigurationBox</a> that applies to the samples associated with this sample entry.</p>
    <p class="note" role="note"><span>NOTE:</span> Multiple instances of <a data-link-type="dfn" href="#av1sampleentry" id="ref-for-av1sampleentry①">AV1SampleEntry</a> may be required when the track contains samples requiring a <a data-link-type="dfn" href="#av1codecconfigurationbox" id="ref-for-av1codecconfigurationbox②">AV1CodecConfigurationBox</a> with different characteristics.</p>
    <p>Optional boxes not specifically mentioned here can be present, in particular those indicated in the definition of the <a data-link-type="dfn" href="https://www.iso.org/standard/68960.html#" id="termref-for-④">VisualSampleEntry</a> in <a data-link-type="biblio" href="#biblio-isobmff">[ISOBMFF]</a>.</p>
    <h3 class="heading settled" data-level="2.3" id="av1codecconfigurationbox-section"><span class="secno">2.3. </span><span class="content">AV1 Codec Configuration Box</span><a class="self-link" href="#av1codecconfigurationbox-section"></a></h3>
    <h4 class="heading settled" data-level="2.3.1" id="av1codecconfigurationbox-definition"><span class="secno">2.3.1. </span><span class="content">Definition</span><a class="self-link" href="#av1codecconfigurationbox-definition"></a></h4>
-<pre class="def">Box Type:  <dfn data-dfn-type="dfn" data-export id="av1c">av1C<a class="self-link" href="#av1c"></a></dfn>
+<pre class="def">Box Type:  <dfn data-dfn-type="dfn" data-export="" id="av1c">av1C<a class="self-link" href="#av1c"></a></dfn>
 Container: AV1 Sample Entry ('av01')
 Mandatory: Yes
 Quantity:  Exactly One
 </pre>
    <h4 class="heading settled" data-level="2.3.2" id="av1codecconfigurationbox-description"><span class="secno">2.3.2. </span><span class="content">Description</span><a class="self-link" href="#av1codecconfigurationbox-description"></a></h4>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="av1codecconfigurationbox">AV1CodecConfigurationBox</dfn> contains decoder configuration information that SHALL be valid for every sample that references the sample entry.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1codecconfigurationbox">AV1CodecConfigurationBox</dfn> contains decoder configuration information that SHALL be valid for every sample that references the sample entry.</p>
    <h4 class="heading settled" data-level="2.3.3" id="av1codecconfigurationbox-syntax"><span class="secno">2.3.3. </span><span class="content">Syntax</span><a class="self-link" href="#av1codecconfigurationbox-syntax"></a></h4>
 <pre>class AV1CodecConfigurationBox extends Box('av1C'){
   AV1CodecConfigurationRecord av1Config;
@@ -1596,9 +1595,9 @@ aligned (8) class AV1CodecConfigurationRecord {
   unsigned int (2) chroma_sample_position;
   unsigned int (3) reserved = 0;
 
-  unsigned int (1) initial_presentation_delay_present;
-  if (initial_presentation_delay_present) {
-    unsigned int (4) initial_presentation_delay_minus_one;
+  unsigned int (1) initial_delay_present;
+  if (initial_delay_present) {
+    unsigned int (4) initial_delay_samples_minus_one;
   } else {
     unsigned int (4) reserved = 0;
   }
@@ -1607,51 +1606,51 @@ aligned (8) class AV1CodecConfigurationRecord {
 }
 </pre>
    <h4 class="heading settled" data-level="2.3.4" id="av1codecconfigurationbox-semantics"><span class="secno">2.3.4. </span><span class="content">Semantics</span><a class="self-link" href="#av1codecconfigurationbox-semantics"></a></h4>
-   <p>The <dfn data-dfn-type="dfn" data-export id="marker">marker<a class="self-link" href="#marker"></a></dfn> field SHALL be set to 1.</p>
+   <p>The <dfn data-dfn-type="dfn" data-export="" id="marker">marker<a class="self-link" href="#marker"></a></dfn> field SHALL be set to 1.</p>
    <p class="note" role="note"><span>NOTE:</span> The marker bit ensures that the bit pattern of the first byte of the AV1CodecConfigurationRecord cannot be mistaken for an <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40">OBU Header</a> byte.</p>
-   <p>The <dfn data-dfn-type="dfn" data-noexport id="version">version<a class="self-link" href="#version"></a></dfn> field indicates the version of the AV1CodecConfigurationRecord. The value SHALL be set to 1 for AV1CodecConfigurationRecord.</p>
-   <p>The <dfn data-dfn-type="dfn" data-export id="seq_profile">seq_profile<a class="self-link" href="#seq_profile"></a></dfn> field indicates the AV1 profile and SHALL be equal to the seq_profile value from the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②">Sequence Header OBU</a>.</p>
-   <p>The <dfn data-dfn-type="dfn" data-export id="seq_level_idx_0">seq_level_idx_0<a class="self-link" href="#seq_level_idx_0"></a></dfn> field indicates the value of seq_level_idx[0] found in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41③">Sequence Header OBU</a> and SHALL be equal to the value of seq_level_idx[0] in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41④">Sequence Header OBU</a>.</p>
-   <p>The <dfn data-dfn-type="dfn" data-export id="seq_tier_0">seq_tier_0<a class="self-link" href="#seq_tier_0"></a></dfn> field indicates the value of seq_tier[0] found in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑤">Sequence Header OBU</a> and SHALL be equal to the value of seq_tier[0] in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑥">Sequence Header OBU</a>.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="high_bitdepth">high_bitdepth</dfn> field indicates the value of the <a data-link-type="dfn" href="#high_bitdepth" id="ref-for-high_bitdepth">high_bitdepth</a> flag from the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑦">Sequence Header OBU</a>.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="twelve_bit">twelve_bit</dfn> field indicates the value of the <a data-link-type="dfn" href="#twelve_bit" id="ref-for-twelve_bit">twelve_bit</a> flag from the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑧">Sequence Header OBU</a>. When twelve_bit is not present in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑨">Sequence Header OBU</a> the AV1CodecConfigurationRecord twelve_bit value SHALL be 0.</p>
-   <p>The <dfn data-dfn-type="dfn" data-export id="monochrome">monochrome<a class="self-link" href="#monochrome"></a></dfn> field indicates the value of the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑧">mono_chrome</a> flag from the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⓪">Sequence Header OBU</a>.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="chroma_subsampling_x">chroma_subsampling_x</dfn> field indicates the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑨">subsampling_x</a> value from the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①①">Sequence Header OBU</a>.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="chroma_subsampling_y">chroma_subsampling_y</dfn> field indicates the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⓪">subsampling_y</a> value from the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①②">Sequence Header OBU</a>.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="chroma_sample_position">chroma_sample_position</dfn> field indicates the <a data-link-type="dfn" href="#chroma_sample_position" id="ref-for-chroma_sample_position">chroma_sample_position</a> value from the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①③">Sequence Header OBU</a>.</p>
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="version">version<a class="self-link" href="#version"></a></dfn> field indicates the version of the AV1CodecConfigurationRecord. The value SHALL be set to 1 for AV1CodecConfigurationRecord.</p>
+   <p>The <dfn data-dfn-type="dfn" data-export="" id="seq_profile">seq_profile<a class="self-link" href="#seq_profile"></a></dfn> field indicates the AV1 profile and SHALL be equal to the seq_profile value from the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②">Sequence Header OBU</a>.</p>
+   <p>The <dfn data-dfn-type="dfn" data-export="" id="seq_level_idx_0">seq_level_idx_0<a class="self-link" href="#seq_level_idx_0"></a></dfn> field indicates the value of seq_level_idx[0] found in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41③">Sequence Header OBU</a> and SHALL be equal to the value of seq_level_idx[0] in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41④">Sequence Header OBU</a>.</p>
+   <p>The <dfn data-dfn-type="dfn" data-export="" id="seq_tier_0">seq_tier_0<a class="self-link" href="#seq_tier_0"></a></dfn> field indicates the value of seq_tier[0] found in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑤">Sequence Header OBU</a> and SHALL be equal to the value of seq_tier[0] in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑥">Sequence Header OBU</a>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="high_bitdepth">high_bitdepth</dfn> field indicates the value of the <a data-link-type="dfn" href="#high_bitdepth" id="ref-for-high_bitdepth">high_bitdepth</a> flag from the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑦">Sequence Header OBU</a>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="twelve_bit">twelve_bit</dfn> field indicates the value of the <a data-link-type="dfn" href="#twelve_bit" id="ref-for-twelve_bit">twelve_bit</a> flag from the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑧">Sequence Header OBU</a>. When twelve_bit is not present in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41⑨">Sequence Header OBU</a> the AV1CodecConfigurationRecord twelve_bit value SHALL be 0.</p>
+   <p>The <dfn data-dfn-type="dfn" data-export="" id="monochrome">monochrome<a class="self-link" href="#monochrome"></a></dfn> field indicates the value of the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑧">mono_chrome</a> flag from the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⓪">Sequence Header OBU</a>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="chroma_subsampling_x">chroma_subsampling_x</dfn> field indicates the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2⑨">subsampling_x</a> value from the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①①">Sequence Header OBU</a>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="chroma_subsampling_y">chroma_subsampling_y</dfn> field indicates the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⓪">subsampling_y</a> value from the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①②">Sequence Header OBU</a>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="chroma_sample_position">chroma_sample_position</dfn> field indicates the <a data-link-type="dfn" href="#chroma_sample_position" id="ref-for-chroma_sample_position">chroma_sample_position</a> value from the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①③">Sequence Header OBU</a>.</p>
    <p>When not specified in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①④">Sequence Header OBU</a>, and not defined by the conditions specified in the <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=44" id="ref-for-page=44">color_config</a>, the values of <a data-link-type="dfn" href="#chroma_subsampling_x" id="ref-for-chroma_subsampling_x">chroma_subsampling_x</a>, <a data-link-type="dfn" href="#chroma_subsampling_y" id="ref-for-chroma_subsampling_y">chroma_subsampling_y</a>, and <a data-link-type="dfn" href="#chroma_sample_position" id="ref-for-chroma_sample_position①">chroma_sample_position</a> SHALL be 0.</p>
-   <p>The <dfn data-dfn-type="dfn" data-export id="initial_presentation_delay_present">initial_presentation_delay_present<a class="self-link" href="#initial_presentation_delay_present"></a></dfn> field indicates the presence of the initial_presentation_delay_minus_one field.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</dfn> field indicates the number of samples (minus one) that need to be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①①">seq_level_idx</a> in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑤">Sequence Header OBU</a> (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:</p>
+   <p>The <dfn data-dfn-type="dfn" data-export="" id="initial_delay_present">initial_delay_present<a class="self-link" href="#initial_delay_present"></a></dfn> field indicates the presence of the initial_delay_samples_minus_one field.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="initial_delay_samples_minus_one">initial_delay_samples_minus_one</dfn> field indicates the number of samples (minus one) that need to be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①①">seq_level_idx</a> in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑤">Sequence Header OBU</a> (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:</p>
    <ul>
-    <li data-md>
+    <li data-md="">
      <p>construct a hypothetical bitstream consisting of the OBUs carried in the sample entry followed by the OBUs carried in all the samples referring to that sample entry,</p>
-    <li data-md>
-     <p>set the first <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①②">initial_display_delay_minus_1</a> field of each <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑥">Sequence Header OBU</a> to the number of frames minus one contained in the first <a data-link-type="dfn" href="#initial_presentation_delay_minus_one" id="ref-for-initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</a> + 1 samples,</p>
-    <li data-md>
+    <li data-md="">
+     <p>set the first <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①②">initial_display_delay_minus_1</a> field of each <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑥">Sequence Header OBU</a> to the number of frames minus one contained in the first <a data-link-type="dfn" href="#initial_delay_samples_minus_one" id="ref-for-initial_delay_samples_minus_one">initial_delay_samples_minus_one</a> + 1 samples,</p>
+    <li data-md="">
      <p>set the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①③">frame_presentation_time</a> field of the frame header of each presentable frame such that it matches the presentation time difference between the sample carrying this frame and the previous sample (if it exists, 0 otherwise),</p>
-    <li data-md>
+    <li data-md="">
      <p>apply the decoder model specified in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> to this hypothetical bitstream using the first operating point. If <code>buffer_removal_time</code> information is present in bitstream for this operating point, the decoding schedule mode SHALL be applied, otherwise the resource availability mode SHALL be applied.</p>
    </ul>
-   <p class="note" role="note"><span>NOTE:</span> With the above procedure, when smooth presentation can be guaranteed after decoding the first sample, initial_presentation_delay_minus_one is 0.</p>
-   <p class="note" role="note"><span>NOTE:</span> Because the above procedure considers all OBUs in all samples associated with a sample entry, if these OBUS form multiple coded video sequences which would have different values of <code>initial_presentation_delay_minus_one</code> if considered separately, the sample entry would signal the larger value.</p>
-   <div class="example" id="example-27bde372">
-    <a class="self-link" href="#example-27bde372"></a> The difference between <a data-link-type="dfn" href="#initial_presentation_delay_minus_one" id="ref-for-initial_presentation_delay_minus_one①">initial_presentation_delay_minus_one</a> and <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①④">initial_display_delay_minus_1</a> can be illustrated by considering the following example: 
+   <p class="note" role="note"><span>NOTE:</span> With the above procedure, when smooth presentation can be guaranteed after decoding the first sample, initial_delay_samples_minus_one is 0.</p>
+   <p class="note" role="note"><span>NOTE:</span> Because the above procedure considers all OBUs in all samples associated with a sample entry, if these OBUS form multiple coded video sequences which would have different values of <code>initial_delay_samples_minus_one</code> if considered separately, the sample entry would signal the larger value.</p>
+   <div class="example" id="example-930eeb8a">
+    <a class="self-link" href="#example-930eeb8a"></a> The difference between <a data-link-type="dfn" href="#initial_delay_samples_minus_one" id="ref-for-initial_delay_samples_minus_one①">initial_delay_samples_minus_one</a> and <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①④">initial_display_delay_minus_1</a> can be illustrated by considering the following example: 
 <pre>a b c d e f g h
 </pre>
     where letters correspond to frames. Assume that <code><a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑤">initial_display_delay_minus_1</a></code> is 2, i.e. that once frame <code>c</code> has been decoded, all other frames in the bitstream can be presented on time. If those frames were grouped into temporal units and samples as follows: 
 <pre>[a] [b c d] [e] [f] [g] [h]
 </pre>
-    <code><a data-link-type="dfn" href="#initial_presentation_delay_minus_one" id="ref-for-initial_presentation_delay_minus_one②">initial_presentation_delay_minus_one</a></code> would be 1 because it takes presentation of 2 samples to ensure that <code>c</code> is decoded.
+    <code><a data-link-type="dfn" href="#initial_delay_samples_minus_one" id="ref-for-initial_delay_samples_minus_one②">initial_delay_samples_minus_one</a></code> would be 1 because it takes presentation of 2 samples to ensure that <code>c</code> is decoded.
 But if the frames were grouped as follows: 
 <pre>[a] [b] [c] [d e f] [g] [h]
 </pre>
-    <code><a data-link-type="dfn" href="#initial_presentation_delay_minus_one" id="ref-for-initial_presentation_delay_minus_one③">initial_presentation_delay_minus_one</a></code> would be 2 because it takes presentation of 3 samples to ensure that <code>c</code> is decoded. 
+    <code><a data-link-type="dfn" href="#initial_delay_samples_minus_one" id="ref-for-initial_delay_samples_minus_one③">initial_delay_samples_minus_one</a></code> would be 2 because it takes presentation of 3 samples to ensure that <code>c</code> is decoded. 
    </div>
-   <p>The <dfn data-dfn-type="dfn" data-export id="configobus">configOBUs<a class="self-link" href="#configobus"></a></dfn> field contains zero or more OBUs. Any OBU may be present provided that the following procedures produce compliant AV1 bitstreams:</p>
+   <p>The <dfn data-dfn-type="dfn" data-export="" id="configobus">configOBUs<a class="self-link" href="#configobus"></a></dfn> field contains zero or more OBUs. Any OBU may be present provided that the following procedures produce compliant AV1 bitstreams:</p>
    <ul>
-    <li data-md>
+    <li data-md="">
      <p>From any sync sample, an AV1 bitstream is formed by first outputting the OBUs contained in the <a data-link-type="dfn" href="#av1codecconfigurationbox" id="ref-for-av1codecconfigurationbox③">AV1CodecConfigurationBox</a> and then by outputing all OBUs in the samples themselves, in order, starting from the sync sample.</p>
-    <li data-md>
+    <li data-md="">
      <p>From any sample marked with the <a data-link-type="dfn" href="#av1forwardkeyframesamplegroupentry" id="ref-for-av1forwardkeyframesamplegroupentry">AV1ForwardKeyFrameSampleGroupEntry</a>, an AV1 bitstream is formed by first outputting the OBUs contained in the <a data-link-type="dfn" href="#av1codecconfigurationbox" id="ref-for-av1codecconfigurationbox④">AV1CodecConfigurationBox</a> and then by outputing all OBUs in the sample itself, then by outputting all OBUs in the samples, in order, starting from the sample at the distance indicated by the sample group.</p>
    </ul>
    <p>Additionally, the configOBUs field SHALL contain at most one <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑦">Sequence Header OBU</a> and if present, it SHALL be the first OBU.</p>
@@ -1665,27 +1664,27 @@ But if the frames were grouped as follows:
    <p class="note" role="note"><span>NOTE:</span> The MasteringDisplayColourVolumeBox <a class="property" data-link-type="propdesc" href="https://www.iso.org/standard/68960.html#" id="termref-for-①②">mdcv</a> and ContentLightLevelBox <a class="property" data-link-type="propdesc" href="https://www.iso.org/standard/68960.html#" id="termref-for-①③">clli</a> have identical syntax to the SMPTE2086MasteringDisplayMetadataBox <a class="property" data-link-type="propdesc" href="https://www.webmproject.org/vp9/mp4/#" id="termref-for-①④">SmDm</a> and ContentLightLevelBox <a class="property" data-link-type="propdesc" href="https://www.webmproject.org/vp9/mp4/#" id="termref-for-①⑤">CoLL</a>, except that they are of type <code>Box</code> and not <code>FullBox</code>. However, the semantics of the MasteringDisplayColourVolumeBox and SMPTE2086MasteringDisplayMetadataBox have important differences and should not be confused.</p>
    <p>Additional boxes may be provided at the end of the <a data-link-type="dfn" href="https://www.iso.org/standard/68960.html#" id="termref-for-①⑥">VisualSampleEntry</a> as permitted by ISOBMFF, that may represent redundant or similar information to the one provided in some OBUs contained in the <a data-link-type="dfn" href="#av1codecconfigurationbox" id="ref-for-av1codecconfigurationbox⑤">AV1CodecConfigurationBox</a>. If the box definition does not indicate that its information overrides the OBU information, in case of conflict, the OBU information should be considered authoritative.</p>
    <h3 class="heading settled" data-level="2.4" id="sampleformat"><span class="secno">2.4. </span><span class="content">AV1 Sample Format</span><a class="self-link" href="#sampleformat"></a></h3>
-   <p>For tracks using the <a data-link-type="dfn" href="#av1sampleentry" id="ref-for-av1sampleentry②">AV1SampleEntry</a>, an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="av1-sample">AV1 Sample</dfn> has the following constraints:</p>
+   <p>For tracks using the <a data-link-type="dfn" href="#av1sampleentry" id="ref-for-av1sampleentry②">AV1SampleEntry</a>, an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1-sample">AV1 Sample</dfn> has the following constraints:</p>
    <ul>
-    <li data-md>
+    <li data-md="">
      <p>the sample data SHALL be a sequence of <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39②">OBUs</a> forming a <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑤">Temporal Unit</a>,</p>
-    <li data-md>
+    <li data-md="">
      <p>each OBU SHALL follow the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②①">open_bitstream_unit</a> <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39" id="ref-for-page=39③">Low Overhead Bitstream Format</a> syntax as specified in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>. Each OBU SHALL have the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②②">obu_has_size_field</a> set to 1 except for the last OBU in the sample, for which <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②③">obu_has_size_field</a> MAY be set to 0, in which case it is assumed to fill the remainder of the sample,</p>
    </ul>
    <p class="note" role="note"><span>NOTE:</span> When extracting OBUs from an ISOBMFF file, and depending on the capabilities of the decoder processing these OBUs, ISOBMFF parsers MAY need to either: set the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②④">obu_has_size_field</a> to 1 for some OBUs if not already set, add the size field in this case, and add <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46②">Temporal Delimiter OBU</a>; or use the length-delimited bitstream format as defined in Annex B of <a data-link-type="dfn" href="#av1s" id="ref-for-av1s">AV1</a>. If encryption is used, similar operations MAY have to be done before or after decryption depending on the demuxer/decryptor/decoder architecture.</p>
    <ul>
-    <li data-md>
+    <li data-md="">
      <p>OBU trailing bits SHOULD be limited to byte alignment and SHOULD not be used for padding,</p>
-    <li data-md>
+    <li data-md="">
      <p>OBUs of type OBU_TEMPORAL_DELIMITER, OBU_PADDING, or OBU_REDUNDANT_FRAME_HEADER SHOULD NOT be used.</p>
-    <li data-md>
+    <li data-md="">
      <p>OBUs of type OBU_TILE_LIST SHALL NOT be used.</p>
    </ul>
    <p>If an AV1 Sample is signaled as a sync sample (in the SyncSampleBox or by setting sample_is_non_sync_sample to 0), it SHALL be a Random Access Point as defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>, i.e. satisfy the following constraints:</p>
    <ul>
-    <li data-md>
+    <li data-md="">
      <p>Its first frame is a <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13⑥">Key Frame</a> that has <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⑤">show_frame</a> flag set to 1,</p>
-    <li data-md>
+    <li data-md="">
      <p>It contains a <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②⑥">Sequence Header OBU</a> before the first <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49①">Frame Header OBU</a>.</p>
    </ul>
    <p class="note" role="note"><span>NOTE:</span> Within this definition, a sync sample may contain additional frames that are not Key Frames. The fact that none of them is the first frame in the temporal unit ensures that they are decodable.</p>
@@ -1700,55 +1699,55 @@ But if the frames were grouped as follows:
    <p>Unless explicitely stated, the grouping_type_parameter is not defined for the SampleToGroupBox with grouping types defined in this specification.</p>
    <h3 class="heading settled" data-level="2.5" id="forwardkeyframesamplegroupentry"><span class="secno">2.5. </span><span class="content">AV1 Forward Key Frame sample group entry</span><a class="self-link" href="#forwardkeyframesamplegroupentry"></a></h3>
    <h4 class="heading settled" data-level="2.5.1" id="forwardkeyframesamplegroupentry-definition"><span class="secno">2.5.1. </span><span class="content">Definition</span><a class="self-link" href="#forwardkeyframesamplegroupentry-definition"></a></h4>
-<pre class="def">Group Type: <dfn data-dfn-type="dfn" data-export id="av1f">av1f<a class="self-link" href="#av1f"></a></dfn>
+<pre class="def">Group Type: <dfn data-dfn-type="dfn" data-export="" id="av1f">av1f<a class="self-link" href="#av1f"></a></dfn>
 Container:  Sample Group Description Box ('sgpd')
 Mandatory:  No
 Quantity:   Zero or more.
 </pre>
    <h4 class="heading settled" data-level="2.5.2" id="forwardkeyframesamplegroupentry-description"><span class="secno">2.5.2. </span><span class="content">Description</span><a class="self-link" href="#forwardkeyframesamplegroupentry-description"></a></h4>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="av1forwardkeyframesamplegroupentry">AV1ForwardKeyFrameSampleGroupEntry</dfn> documents samples that contain a <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑧">Delayed Random Access Point</a> that are followed at a given distance in the bitstream by a <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑨">Key Frame Dependent Recovery Point</a>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1forwardkeyframesamplegroupentry">AV1ForwardKeyFrameSampleGroupEntry</dfn> documents samples that contain a <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑧">Delayed Random Access Point</a> that are followed at a given distance in the bitstream by a <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206⑨">Key Frame Dependent Recovery Point</a>.</p>
    <h4 class="heading settled" data-level="2.5.3" id="forwardkeyframesamplegroupentry-syntax"><span class="secno">2.5.3. </span><span class="content">Syntax</span><a class="self-link" href="#forwardkeyframesamplegroupentry-syntax"></a></h4>
 <pre>class AV1ForwardKeyFrameSampleGroupEntry extends VisualSampleGroupEntry('av1f') {
   unsigned int(8) fwd_distance;
 }
 </pre>
    <h4 class="heading settled" data-level="2.5.4" id="forwardkeyframesamplegroupentry-semantics"><span class="secno">2.5.4. </span><span class="content">Semantics</span><a class="self-link" href="#forwardkeyframesamplegroupentry-semantics"></a></h4>
-   <p>The <dfn data-dfn-type="dfn" data-export id="fwd_distance">fwd_distance<a class="self-link" href="#fwd_distance"></a></dfn> field indicates the number of samples between this sample and the next sample containing the associated <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206①⓪">Key Frame Dependent Recovery Point</a>. 0 means the next sample.</p>
+   <p>The <dfn data-dfn-type="dfn" data-export="" id="fwd_distance">fwd_distance<a class="self-link" href="#fwd_distance"></a></dfn> field indicates the number of samples between this sample and the next sample containing the associated <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=206" id="ref-for-page=206①⓪">Key Frame Dependent Recovery Point</a>. 0 means the next sample.</p>
    <h3 class="heading settled" data-level="2.6" id="multiframesamplegroupentry"><span class="secno">2.6. </span><span class="content">AV1 Multi-Frame sample group entry</span><a class="self-link" href="#multiframesamplegroupentry"></a></h3>
    <h4 class="heading settled" data-level="2.6.1" id="multiframesamplegroupentry-definition"><span class="secno">2.6.1. </span><span class="content">Definition</span><a class="self-link" href="#multiframesamplegroupentry-definition"></a></h4>
-<pre class="def">Group Type: <dfn data-dfn-for="AV1MultiFrameSampleGroupEntry" data-dfn-type="value" data-export id="valdef-av1multiframesamplegroupentry-av1m">av1m<a class="self-link" href="#valdef-av1multiframesamplegroupentry-av1m"></a></dfn>
+<pre class="def">Group Type: <dfn data-dfn-for="AV1MultiFrameSampleGroupEntry" data-dfn-type="value" data-export="" id="valdef-av1multiframesamplegroupentry-av1m">av1m<a class="self-link" href="#valdef-av1multiframesamplegroupentry-av1m"></a></dfn>
 Container:  Sample Group Description Box ('sgpd')
 Mandatory:  No
 Quantity:   Zero or more.
 </pre>
    <h4 class="heading settled" data-level="2.6.2" id="multiframesamplegroupentry-description"><span class="secno">2.6.2. </span><span class="content">Description</span><a class="self-link" href="#multiframesamplegroupentry-description"></a></h4>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="av1multiframesamplegroupentry">AV1MultiFrameSampleGroupEntry</dfn> documents samples that contain multiple frames.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1multiframesamplegroupentry">AV1MultiFrameSampleGroupEntry</dfn> documents samples that contain multiple frames.</p>
    <h4 class="heading settled" data-level="2.6.3" id="multiframesamplegroupentry-syntax"><span class="secno">2.6.3. </span><span class="content">Syntax</span><a class="self-link" href="#multiframesamplegroupentry-syntax"></a></h4>
 <pre>class AV1MultiFrameSampleGroupEntry extends VisualSampleGroupEntry('av1m') {
 }
 </pre>
    <h3 class="heading settled" data-level="2.7" id="switchframesamplegroupentry"><span class="secno">2.7. </span><span class="content">AV1 Switch Frame sample group entry</span><a class="self-link" href="#switchframesamplegroupentry"></a></h3>
    <h4 class="heading settled" data-level="2.7.1" id="switchframesamplegroupentry-definition"><span class="secno">2.7.1. </span><span class="content">Definition</span><a class="self-link" href="#switchframesamplegroupentry-definition"></a></h4>
-<pre class="def">Group Type: <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="av1s">av1s</dfn>
+<pre class="def">Group Type: <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="av1s">av1s</dfn>
 Container:  Sample Group Description Box ('sgpd')
 Mandatory:  No
 Quantity:   Zero or more.
 </pre>
    <h4 class="heading settled" data-level="2.7.2" id="switchframesamplegroupentry-description"><span class="secno">2.7.2. </span><span class="content">Description</span><a class="self-link" href="#switchframesamplegroupentry-description"></a></h4>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="av1switchframesamplegroupentry">AV1SwitchFrameSampleGroupEntry</dfn> documents samples that start with a <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13①⓪">Switch Frame</a>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1switchframesamplegroupentry">AV1SwitchFrameSampleGroupEntry</dfn> documents samples that start with a <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=13" id="ref-for-page=13①⓪">Switch Frame</a>.</p>
    <h4 class="heading settled" data-level="2.7.3" id="switchframesamplegroupentry-syntax"><span class="secno">2.7.3. </span><span class="content">Syntax</span><a class="self-link" href="#switchframesamplegroupentry-syntax"></a></h4>
 <pre>class AV1SwitchFrameSampleGroupEntry extends VisualSampleGroupEntry('av1s') {
 }
 </pre>
    <h3 class="heading settled" data-level="2.8" id="metadatasamplegroupentry"><span class="secno">2.8. </span><span class="content">AV1 Metadata sample group entry</span><a class="self-link" href="#metadatasamplegroupentry"></a></h3>
    <h4 class="heading settled" data-level="2.8.1" id="metadatasamplegroupentry-definition"><span class="secno">2.8.1. </span><span class="content">Definition</span><a class="self-link" href="#metadatasamplegroupentry-definition"></a></h4>
-<pre class="def">Group Type: <dfn data-dfn-for="AV1MetadataSampleGroupEntry" data-dfn-type="value" data-noexport id="valdef-av1metadatasamplegroupentry-av1m">av1M<a class="self-link" href="#valdef-av1metadatasamplegroupentry-av1m"></a></dfn>
+<pre class="def">Group Type: <dfn data-dfn-for="AV1MetadataSampleGroupEntry" data-dfn-type="value" data-noexport="" id="valdef-av1metadatasamplegroupentry-av1m">av1M<a class="self-link" href="#valdef-av1metadatasamplegroupentry-av1m"></a></dfn>
 Container:  Sample Group Description Box ('sgpd')
 Mandatory:  No
 Quantity:   Zero or more.
 </pre>
    <h4 class="heading settled" data-level="2.8.2" id="metadatasamplegroupentry-description"><span class="secno">2.8.2. </span><span class="content">Description</span><a class="self-link" href="#metadatasamplegroupentry-description"></a></h4>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="av1metadatasamplegroupentry">AV1MetadataSampleGroupEntry</dfn> documents samples that contain <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46⑥">metadata OBUs</a>. The <code>grouping_type_parameter</code> can be used to identify samples containing <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46⑦">metadata OBUs</a> of a given type. If no <code>grouping_type_parameter</code> is provided, the sample group entry identifies samples containing <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46⑧">metadata OBUs</a> for which the <code>metadata_type</code> is unknown.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="av1metadatasamplegroupentry">AV1MetadataSampleGroupEntry</dfn> documents samples that contain <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46⑥">metadata OBUs</a>. The <code>grouping_type_parameter</code> can be used to identify samples containing <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46⑦">metadata OBUs</a> of a given type. If no <code>grouping_type_parameter</code> is provided, the sample group entry identifies samples containing <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46⑧">metadata OBUs</a> for which the <code>metadata_type</code> is unknown.</p>
    <h4 class="heading settled" data-level="2.8.3" id="metadatasamplegroupentry-syntax"><span class="secno">2.8.3. </span><span class="content">Syntax</span><a class="self-link" href="#metadatasamplegroupentry-syntax"></a></h4>
 <pre>class AV1MetadataSampleGroupEntry extends VisualSampleGroupEntry('av1M') {
 }
@@ -1760,29 +1759,29 @@ Quantity:   Zero or more.
 }
 </pre>
    <h4 class="heading settled" data-level="2.8.4" id="metadatasamplegroupentry-semantics"><span class="secno">2.8.4. </span><span class="content">Semantics</span><a class="self-link" href="#metadatasamplegroupentry-semantics"></a></h4>
-   <p><dfn data-dfn-type="dfn" data-export id="metadata_type">metadata_type<a class="self-link" href="#metadata_type"></a></dfn> is a 8-bit field whose value is the value of the metadata_type field defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>, when it is equal or lower than 255. metadata_type values above 255 are not supported by this sample group.</p>
-   <p><dfn data-dfn-type="dfn" data-export id="metadata_specific_parameters">metadata_specific_parameters<a class="self-link" href="#metadata_specific_parameters"></a></dfn> provides an additional part of the <code>grouping_type_parameter</code>, which MAY be used to distinguish different sample groups having the same <code>metadata_type</code> but different sub-parameters. In this version of the specification, <code>metadata_specific_parameters</code> is only defined when <code>metadata_type</code> is set to <code>METADATA_TYPE_ITUT_T35</code> in which case its value SHALL be set to the first 24 bits of the <code>metadata_itut_t35</code> structure. For other types of metadata, its value SHOULD be set to 0. In all cases, when the <code>grouping_type_parameter</code> is used, readers processing sample groups SHALL use the entire value of <code>grouping_type_parameter</code>.</p>
+   <p><dfn data-dfn-type="dfn" data-export="" id="metadata_type">metadata_type<a class="self-link" href="#metadata_type"></a></dfn> is a 8-bit field whose value is the value of the metadata_type field defined in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a>, when it is equal or lower than 255. metadata_type values above 255 are not supported by this sample group.</p>
+   <p><dfn data-dfn-type="dfn" data-export="" id="metadata_specific_parameters">metadata_specific_parameters<a class="self-link" href="#metadata_specific_parameters"></a></dfn> provides an additional part of the <code>grouping_type_parameter</code>, which MAY be used to distinguish different sample groups having the same <code>metadata_type</code> but different sub-parameters. In this version of the specification, <code>metadata_specific_parameters</code> is only defined when <code>metadata_type</code> is set to <code>METADATA_TYPE_ITUT_T35</code> in which case its value SHALL be set to the first 24 bits of the <code>metadata_itut_t35</code> structure. For other types of metadata, its value SHOULD be set to 0. In all cases, when the <code>grouping_type_parameter</code> is used, readers processing sample groups SHALL use the entire value of <code>grouping_type_parameter</code>.</p>
    <h2 class="heading settled" data-level="3" id="cmaf"><span class="secno">3. </span><span class="content">CMAF AV1 track format</span><a class="self-link" href="#cmaf"></a></h2>
    <p><a data-link-type="biblio" href="#biblio-cmaf">[CMAF]</a> defines structural constraints on ISOBMFF files additional to <a data-link-type="biblio" href="#biblio-isobmff">[ISOBMFF]</a> for the purpose of, for example, adaptive streaming or for protected files. Conformance to these structural constraints is signaled by the presence of the brand <code><a data-link-type="dfn" href="https://www.iso.org/standard/71975.html#" id="termref-for-①⑨">cmfc</a></code> in the <code>FileTypeBox</code>.</p>
-   <p>If a <a data-link-type="dfn" href="https://www.iso.org/standard/71975.html#" id="termref-for-②⓪">CMAF Video Track</a> uses the brand <code>av01</code>, it is called a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="cmaf-av1-track">CMAF AV1 Track</dfn> and the following constraints, defining the CMAF Media Profile for AV1, apply:</p>
+   <p>If a <a data-link-type="dfn" href="https://www.iso.org/standard/71975.html#" id="termref-for-②⓪">CMAF Video Track</a> uses the brand <code>av01</code>, it is called a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="cmaf-av1-track">CMAF AV1 Track</dfn> and the following constraints, defining the CMAF Media Profile for AV1, apply:</p>
    <ul>
-    <li data-md>
+    <li data-md="">
      <p>it SHALL use an <a data-link-type="dfn" href="#av1sampleentry" id="ref-for-av1sampleentry④">AV1SampleEntry</a></p>
-    <li data-md>
+    <li data-md="">
      <p>it MAY use multiple sample entries, and in that case the following values SHALL not change in the track:</p>
      <ul>
-      <li data-md>
+      <li data-md="">
        <p><code>seq_profile</code></p>
-      <li data-md>
+      <li data-md="">
        <p><code>still_picture</code></p>
-      <li data-md>
+      <li data-md="">
        <p>the first value of <code>seq_level_idx</code></p>
-      <li data-md>
+      <li data-md="">
        <p>the first value of <code>seq_tier</code></p>
-      <li data-md>
+      <li data-md="">
        <p><code>color_config</code></p>
-      <li data-md>
-       <p><code>initial_presentation_delay_minus_one</code></p>
+      <li data-md="">
+       <p><code>initial_delay_samples_minus_one</code></p>
      </ul>
    </ul>
    <p>When protected, <a data-link-type="dfn" href="#cmaf-av1-track" id="ref-for-cmaf-av1-track">CMAF AV1 Tracks</a> SHALL use the signaling defined in <a data-link-type="biblio" href="#biblio-cmaf">[CMAF]</a>, which in turn relies on <a data-link-type="biblio" href="#biblio-cenc">[CENC]</a>, with the provisions specified in <a href="#CommonEncryption">§4 Common Encryption</a>.</p>
@@ -1793,35 +1792,35 @@ Quantity:   Zero or more.
    <h3 class="heading settled" data-level="4.1" id="subsample-encryption"><span class="secno">4.1. </span><span class="content">General Subsample Encryption constraints</span><a class="self-link" href="#subsample-encryption"></a></h3>
    <p>Within protected samples, the following constraints apply:</p>
    <ul>
-    <li data-md>
+    <li data-md="">
      <p>Protected samples SHALL be exactly spanned by one or more contiguous subsamples.</p>
      <ul>
-      <li data-md>
+      <li data-md="">
        <p>An OBU MAY be spanned by one or more subsamples, especially when it has multiple ranges of protected data. However, as recommended in <a data-link-type="biblio" href="#biblio-cenc">[CENC]</a>, writers SHOULD reduce the number of subsamples as possible. This can be achieved by using a subsample that spans multiple consecutive unprotected OBUs as well as the first unprotected and protected parts of the following protected OBU, if such protected OBU exists.</p>
-      <li data-md>
+      <li data-md="">
        <p>A large unprotected OBU whose data size is larger than the maximum size of a single <a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-②⑤">BytesOfClearData</a> field MAY be spanned by multiple subsamples with zero size <a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-②⑥">BytesOfProtectedData</a>.</p>
      </ul>
-    <li data-md>
+    <li data-md="">
      <p>All <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=40" id="ref-for-page=40①">OBU Headers</a> and associated <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2②⑥">obu_size</a> fields SHALL be unprotected.</p>
-    <li data-md>
+    <li data-md="">
      <p><a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46⑨">Temporal Delimiter OBUs</a>, <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41②⑧">Sequence Header OBUs</a>, and <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=49" id="ref-for-page=49②">Frame Header OBUs</a> (including within a <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71">Frame OBU</a>), <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=121" id="ref-for-page=121①">Redundant Frame Header OBUs</a> and <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=121" id="ref-for-page=121②">Padding OBUs</a> SHALL be unprotected.</p>
-    <li data-md>
+    <li data-md="">
      <p><a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=46" id="ref-for-page=46①⓪">Metadata OBUs</a> MAY be protected.</p>
-    <li data-md>
+    <li data-md="">
      <p><a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71①">Tile Group OBUs</a> and <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71②">Frame OBUs</a> SHALL be protected. Within <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71③">Tile Group OBUs</a> or <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71④">Frame OBUs</a>, the following applies:</p>
      <ul>
-      <li data-md>
+      <li data-md="">
        <p><a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-②⑦">BytesOfProtectedData</a> SHALL be a multiple of 16 bytes.</p>
-      <li data-md>
+      <li data-md="">
        <p><a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-②⑧">BytesOfProtectedData</a> SHALL end on the last byte of the <code>decode_tile</code> structure (including any trailing bits).</p>
-      <li data-md>
+      <li data-md="">
        <p><a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-②⑨">BytesOfProtectedData</a> SHALL span all complete 16-byte blocks of the <code>decode_tile</code> structure (including any trailing bits).</p>
      </ul>
      <p class="note" role="note"><span>NOTE:</span> As a result of the above, partial blocks are not used and it is possible that <a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-③⓪">BytesOfProtectedData</a> does not start at the first byte of the <code>decode_tile</code> structure, but some number of bytes following that.</p>
      <ul>
-      <li data-md>
+      <li data-md="">
        <p>A subsample SHALL be created for each tile that has a <code>decode_tile</code> structure whose size (including any trailing bits) is larger or equal to 16 bytes. If it is less than 16 bytes, per the rules above, the <code>decode_tile</code> structure is not encrypted and the corresponding bytes SHOULD be included in the <a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-③①">BytesOfClearData</a> field of a surrounding subsample, if any.</p>
-      <li data-md>
+      <li data-md="">
        <p>All other parts of <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71⑤">Tile Group OBUs</a> and <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71⑥">Frame OBUs</a> SHALL be unprotected.</p>
      </ul>
    </ul>
@@ -1872,9 +1871,9 @@ Quantity:   Zero or more.
    <p>If any character that is not '.', digits, part of the AV1 4CC, or a tier value is encountered, the string SHALL be interpreted ignoring all the characters starting from that character.</p>
    <h2 class="heading settled" data-level="6" id="changelist"><span class="secno">6. </span><span class="content">Changes since v1.0.0 release</span><a class="self-link" href="#changelist"></a></h2>
    <ul>
-    <li data-md>
+    <li data-md="">
      <p><a href="https://github.com/AOMediaCodec/av1-isobmff/pull/103"> Clarify values of AV1CodecConfigurationRecord fields when not present in the Sequence Header OBU.</a></p>
-    <li data-md>
+    <li data-md="">
      <p><a href="https://github.com/AOMediaCodec/av1-isobmff/pull/106"> Relax the rules for the creation of encryption subsamples when tile data is less than an encryption block.</a></p>
    </ul>
   </main>
@@ -2055,8 +2054,8 @@ Quantity:   Zero or more.
    <li><a href="#fwd_distance">fwd_distance</a><span>, in §2.5.4</span>
    <li><a href="#height">height</a><span>, in §2.2.4</span>
    <li><a href="#high_bitdepth">high_bitdepth</a><span>, in §2.3.4</span>
-   <li><a href="#initial_presentation_delay_minus_one">initial_presentation_delay_minus_one</a><span>, in §2.3.4</span>
-   <li><a href="#initial_presentation_delay_present">initial_presentation_delay_present</a><span>, in §2.3.4</span>
+   <li><a href="#initial_delay_present">initial_delay_present</a><span>, in §2.3.4</span>
+   <li><a href="#initial_delay_samples_minus_one">initial_delay_samples_minus_one</a><span>, in §2.3.4</span>
    <li><a href="#marker">marker</a><span>, in §2.3.4</span>
    <li><a href="#metadata_specific_parameters">metadata_specific_parameters</a><span>, in §2.8.4</span>
    <li><a href="#metadata_type">metadata_type</a><span>, in §2.8.4</span>
@@ -2708,10 +2707,10 @@ Quantity:   Zero or more.
     <li><a href="#ref-for-chroma_sample_position">2.3.4. Semantics</a> <a href="#ref-for-chroma_sample_position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initial_presentation_delay_minus_one">
-   <b><a href="#initial_presentation_delay_minus_one">#initial_presentation_delay_minus_one</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="initial_delay_samples_minus_one">
+   <b><a href="#initial_delay_samples_minus_one">#initial_delay_samples_minus_one</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-initial_presentation_delay_minus_one">2.3.4. Semantics</a> <a href="#ref-for-initial_presentation_delay_minus_one①">(2)</a> <a href="#ref-for-initial_presentation_delay_minus_one②">(3)</a> <a href="#ref-for-initial_presentation_delay_minus_one③">(4)</a>
+    <li><a href="#ref-for-initial_delay_samples_minus_one">2.3.4. Semantics</a> <a href="#ref-for-initial_delay_samples_minus_one①">(2)</a> <a href="#ref-for-initial_delay_samples_minus_one②">(3)</a> <a href="#ref-for-initial_delay_samples_minus_one③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="av1-sample">

--- a/index.html
+++ b/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 0e8880531a1904b4bc0b037759fa3cb386293992" name="generator">
   <link href="https://aomediacodec.github.io/av1-isobmff/" rel="canonical">
-  <meta content="0a8261dba84de338a1f9ee5e323d8ab5983c2017" name="document-revision">
+  <meta content="41f57f38415012aab4ed031244329c5049471ca9" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1595,9 +1595,9 @@ aligned (8) class AV1CodecConfigurationRecord {
   unsigned int (2) chroma_sample_position;
   unsigned int (3) reserved = 0;
 
-  unsigned int (1) initial_delay_present;
-  if (initial_delay_present) {
-    unsigned int (4) initial_delay_samples_minus_one;
+  unsigned int (1) initial_display_delay_present;
+  if (initial_display_delay_present) {
+    unsigned int (4) initial_display_delay_in_samples_minus_1;
   } else {
     unsigned int (4) reserved = 0;
   }
@@ -1619,32 +1619,32 @@ aligned (8) class AV1CodecConfigurationRecord {
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="chroma_subsampling_y">chroma_subsampling_y</dfn> field indicates the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⓪">subsampling_y</a> value from the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①②">Sequence Header OBU</a>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="chroma_sample_position">chroma_sample_position</dfn> field indicates the <a data-link-type="dfn" href="#chroma_sample_position" id="ref-for-chroma_sample_position">chroma_sample_position</a> value from the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①③">Sequence Header OBU</a>.</p>
    <p>When not specified in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①④">Sequence Header OBU</a>, and not defined by the conditions specified in the <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=44" id="ref-for-page=44">color_config</a>, the values of <a data-link-type="dfn" href="#chroma_subsampling_x" id="ref-for-chroma_subsampling_x">chroma_subsampling_x</a>, <a data-link-type="dfn" href="#chroma_subsampling_y" id="ref-for-chroma_subsampling_y">chroma_subsampling_y</a>, and <a data-link-type="dfn" href="#chroma_sample_position" id="ref-for-chroma_sample_position①">chroma_sample_position</a> SHALL be 0.</p>
-   <p>The <dfn data-dfn-type="dfn" data-export="" id="initial_delay_present">initial_delay_present<a class="self-link" href="#initial_delay_present"></a></dfn> field indicates the presence of the initial_delay_samples_minus_one field.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="initial_delay_samples_minus_one">initial_delay_samples_minus_one</dfn> field indicates the number of samples (minus one) that need to be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①①">seq_level_idx</a> in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑤">Sequence Header OBU</a> (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:</p>
+   <p>The <dfn data-dfn-type="dfn" data-export="" id="initial_display_delay_present">initial_display_delay_present<a class="self-link" href="#initial_display_delay_present"></a></dfn> field indicates the presence of the initial_display_delay_in_samples_minus_1 field.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="initial_display_delay_in_samples_minus_1">initial_display_delay_in_samples_minus_1</dfn> field indicates the number of samples (minus one) that need to be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①①">seq_level_idx</a> in the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑤">Sequence Header OBU</a> (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:</p>
    <ul>
     <li data-md="">
      <p>construct a hypothetical bitstream consisting of the OBUs carried in the sample entry followed by the OBUs carried in all the samples referring to that sample entry,</p>
     <li data-md="">
-     <p>set the first <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①②">initial_display_delay_minus_1</a> field of each <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑥">Sequence Header OBU</a> to the number of frames minus one contained in the first <a data-link-type="dfn" href="#initial_delay_samples_minus_one" id="ref-for-initial_delay_samples_minus_one">initial_delay_samples_minus_one</a> + 1 samples,</p>
+     <p>set the first <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①②">initial_display_delay_minus_1</a> field of each <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41" id="ref-for-page=41①⑥">Sequence Header OBU</a> to the number of frames minus one contained in the first <a data-link-type="dfn" href="#initial_display_delay_in_samples_minus_1" id="ref-for-initial_display_delay_in_samples_minus_1">initial_display_delay_in_samples_minus_1</a> + 1 samples,</p>
     <li data-md="">
      <p>set the <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①③">frame_presentation_time</a> field of the frame header of each presentable frame such that it matches the presentation time difference between the sample carrying this frame and the previous sample (if it exists, 0 otherwise),</p>
     <li data-md="">
      <p>apply the decoder model specified in <a data-link-type="biblio" href="#biblio-av1">[AV1]</a> to this hypothetical bitstream using the first operating point. If <code>buffer_removal_time</code> information is present in bitstream for this operating point, the decoding schedule mode SHALL be applied, otherwise the resource availability mode SHALL be applied.</p>
    </ul>
-   <p class="note" role="note"><span>NOTE:</span> With the above procedure, when smooth presentation can be guaranteed after decoding the first sample, initial_delay_samples_minus_one is 0.</p>
-   <p class="note" role="note"><span>NOTE:</span> Because the above procedure considers all OBUs in all samples associated with a sample entry, if these OBUS form multiple coded video sequences which would have different values of <code>initial_delay_samples_minus_one</code> if considered separately, the sample entry would signal the larger value.</p>
-   <div class="example" id="example-930eeb8a">
-    <a class="self-link" href="#example-930eeb8a"></a> The difference between <a data-link-type="dfn" href="#initial_delay_samples_minus_one" id="ref-for-initial_delay_samples_minus_one①">initial_delay_samples_minus_one</a> and <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①④">initial_display_delay_minus_1</a> can be illustrated by considering the following example: 
+   <p class="note" role="note"><span>NOTE:</span> With the above procedure, when smooth presentation can be guaranteed after decoding the first sample, initial_display_delay_in_samples_minus_1 is 0.</p>
+   <p class="note" role="note"><span>NOTE:</span> Because the above procedure considers all OBUs in all samples associated with a sample entry, if these OBUS form multiple coded video sequences which would have different values of <code>initial_display_delay_in_samples_minus_1</code> if considered separately, the sample entry would signal the larger value.</p>
+   <div class="example" id="example-88fb8c91">
+    <a class="self-link" href="#example-88fb8c91"></a> The difference between <a data-link-type="dfn" href="#initial_display_delay_in_samples_minus_1" id="ref-for-initial_display_delay_in_samples_minus_1①">initial_display_delay_in_samples_minus_1</a> and <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①④">initial_display_delay_minus_1</a> can be illustrated by considering the following example: 
 <pre>a b c d e f g h
 </pre>
     where letters correspond to frames. Assume that <code><a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=2" id="ref-for-page=2①⑤">initial_display_delay_minus_1</a></code> is 2, i.e. that once frame <code>c</code> has been decoded, all other frames in the bitstream can be presented on time. If those frames were grouped into temporal units and samples as follows: 
 <pre>[a] [b c d] [e] [f] [g] [h]
 </pre>
-    <code><a data-link-type="dfn" href="#initial_delay_samples_minus_one" id="ref-for-initial_delay_samples_minus_one②">initial_delay_samples_minus_one</a></code> would be 1 because it takes presentation of 2 samples to ensure that <code>c</code> is decoded.
+    <code><a data-link-type="dfn" href="#initial_display_delay_in_samples_minus_1" id="ref-for-initial_display_delay_in_samples_minus_1②">initial_display_delay_in_samples_minus_1</a></code> would be 1 because it takes presentation of 2 samples to ensure that <code>c</code> is decoded.
 But if the frames were grouped as follows: 
 <pre>[a] [b] [c] [d e f] [g] [h]
 </pre>
-    <code><a data-link-type="dfn" href="#initial_delay_samples_minus_one" id="ref-for-initial_delay_samples_minus_one③">initial_delay_samples_minus_one</a></code> would be 2 because it takes presentation of 3 samples to ensure that <code>c</code> is decoded. 
+    <code><a data-link-type="dfn" href="#initial_display_delay_in_samples_minus_1" id="ref-for-initial_display_delay_in_samples_minus_1③">initial_display_delay_in_samples_minus_1</a></code> would be 2 because it takes presentation of 3 samples to ensure that <code>c</code> is decoded. 
    </div>
    <p>The <dfn data-dfn-type="dfn" data-export="" id="configobus">configOBUs<a class="self-link" href="#configobus"></a></dfn> field contains zero or more OBUs. Any OBU may be present provided that the following procedures produce compliant AV1 bitstreams:</p>
    <ul>
@@ -1781,7 +1781,7 @@ Quantity:   Zero or more.
       <li data-md="">
        <p><code>color_config</code></p>
       <li data-md="">
-       <p><code>initial_delay_samples_minus_one</code></p>
+       <p><code>initial_display_delay_in_samples_minus_1</code></p>
      </ul>
    </ul>
    <p>When protected, <a data-link-type="dfn" href="#cmaf-av1-track" id="ref-for-cmaf-av1-track">CMAF AV1 Tracks</a> SHALL use the signaling defined in <a data-link-type="biblio" href="#biblio-cmaf">[CMAF]</a>, which in turn relies on <a data-link-type="biblio" href="#biblio-cenc">[CENC]</a>, with the provisions specified in <a href="#CommonEncryption">§4 Common Encryption</a>.</p>
@@ -2054,8 +2054,8 @@ Quantity:   Zero or more.
    <li><a href="#fwd_distance">fwd_distance</a><span>, in §2.5.4</span>
    <li><a href="#height">height</a><span>, in §2.2.4</span>
    <li><a href="#high_bitdepth">high_bitdepth</a><span>, in §2.3.4</span>
-   <li><a href="#initial_delay_present">initial_delay_present</a><span>, in §2.3.4</span>
-   <li><a href="#initial_delay_samples_minus_one">initial_delay_samples_minus_one</a><span>, in §2.3.4</span>
+   <li><a href="#initial_display_delay_in_samples_minus_1">initial_display_delay_in_samples_minus_1</a><span>, in §2.3.4</span>
+   <li><a href="#initial_display_delay_present">initial_display_delay_present</a><span>, in §2.3.4</span>
    <li><a href="#marker">marker</a><span>, in §2.3.4</span>
    <li><a href="#metadata_specific_parameters">metadata_specific_parameters</a><span>, in §2.8.4</span>
    <li><a href="#metadata_type">metadata_type</a><span>, in §2.8.4</span>
@@ -2707,10 +2707,10 @@ Quantity:   Zero or more.
     <li><a href="#ref-for-chroma_sample_position">2.3.4. Semantics</a> <a href="#ref-for-chroma_sample_position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initial_delay_samples_minus_one">
-   <b><a href="#initial_delay_samples_minus_one">#initial_delay_samples_minus_one</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="initial_display_delay_in_samples_minus_1">
+   <b><a href="#initial_display_delay_in_samples_minus_1">#initial_display_delay_in_samples_minus_1</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-initial_delay_samples_minus_one">2.3.4. Semantics</a> <a href="#ref-for-initial_delay_samples_minus_one①">(2)</a> <a href="#ref-for-initial_delay_samples_minus_one②">(3)</a> <a href="#ref-for-initial_delay_samples_minus_one③">(4)</a>
+    <li><a href="#ref-for-initial_display_delay_in_samples_minus_1">2.3.4. Semantics</a> <a href="#ref-for-initial_display_delay_in_samples_minus_1①">(2)</a> <a href="#ref-for-initial_display_delay_in_samples_minus_1②">(3)</a> <a href="#ref-for-initial_display_delay_in_samples_minus_1③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="av1-sample">


### PR DESCRIPTION
This editorial change renames the initial presentation
delay fields to avoid confusion between the ISOBMFF value,
which is in samples, and the AV1 bitstream value, which is
in frames.

- Rename initial_presentation_delay_present to
  initial_display_delay_present.
- Rename initial_presentation_delay_minus_one to
  initial_display_delay_in_samples_minus_1.

Closes https://github.com/AOMediaCodec/av1-isobmff/issues/104