### PR TITLE
enable start alignment only in cbcs mode

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -562,7 +562,7 @@ General Subsample Encryption constraints {#subsample-encryption}
 
 Within protected samples, the following constraints apply:
 - Protected samples SHALL be exactly spanned by one or more contiguous subsamples.
-	- An OBU MAY be spanned by one or more subsamples, especially when it has multiple ranges of protected data. However, as recommended in [[!CENC]], writers SHOULD reduce the number of subsamples as possible. This can be achieved by using a subsample that spans multiple consecutive unprotected OBUs as well as the first unprotected and protected parts of the following protected OBU, if such protected OBU exists.
+	- An OBU MAY be spanned by one or more subsamples, especially when it has multiple ranges of protected data, e.g. when tiles are used. However, as recommended in [[!CENC]], writers SHOULD reduce the number of subsamples as possible. This can be achieved by using a subsample that spans multiple consecutive unprotected OBUs as well as the first unprotected and protected parts of the following protected OBU, if such protected OBU exists.
 	- A large unprotected OBU whose data size is larger than the maximum size of a single [=BytesOfClearData=] field MAY be spanned by multiple subsamples with zero size [=BytesOfProtectedData=].
 
 - All [=OBU Headers=] and associated [=obu_size=] fields SHALL be unprotected.
@@ -570,8 +570,10 @@ Within protected samples, the following constraints apply:
 - [=Metadata OBUs=] MAY be protected.
 - [=Tile Group OBUs=] and [=Frame OBUs=] SHALL be protected. Within [=Tile Group OBUs=] or [=Frame OBUs=], the following applies:
     - [=BytesOfProtectedData=] SHALL be a multiple of 16 bytes.
-    - [=BytesOfProtectedData=] SHALL end on the last byte of the <code>decode_tile</code> structure (including any trailing bits).
-    - [=BytesOfProtectedData=] SHALL span all complete 16-byte blocks of the <code>decode_tile</code> structure (including any trailing bits).
+    - [=BytesOfProtectedData=] SHALL:
+    	- end on the last byte of the <code>decode_tile</code> structure (including any trailing bits), when the protected scheme is either <code>[=cenc=]</code> or <code>[=cbcs=]</code>,
+    	- or start on the first byte of the <code>decode_tile</code> structure, when the protected scheme is <code>[=cbcs=]</code>.
+    - [=BytesOfProtectedData=] SHALL span all complete 16-byte blocks of the <code>decode_tile</code> structure (including any trailing bits if end alignment is used when the protected scheme is <code>[=cbcs=]</code>).
 
     NOTE: As a result of the above, partial blocks are not used and it is possible that [=BytesOfProtectedData=] does not start at the first byte of the <code>decode_tile</code> structure, but some number of bytes following that.
     - A subsample SHALL be created for each tile that has a <code>decode_tile</code> structure whose size (including any trailing bits) is larger or equal to 16 bytes. If it is less than 16 bytes, per the rules above, the <code>decode_tile</code> structure is not encrypted and the corresponding bytes SHOULD be included in the [=BytesOfClearData=] field of a surrounding subsample, if any.

--- a/index.html
+++ b/index.html
@@ -1212,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 018be3f805d3272ce699a232398d6e3902d1ea8d" name="generator">
+  <meta content="Bikeshed version 872cce6d3026423d677f3bd5837f1a1a46299a04" name="generator">
   <link href="https://aomediacodec.github.io/av1-isobmff/" rel="canonical">
-  <meta content="dd772d89082a13a80c3b435a304ad67a1af28b43" name="document-revision">
+  <meta content="8a2e4cf41d03ccfb61a052de48befa1c1ad8b0b5" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1403,7 +1403,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">AV1 Codec ISO Media File Format Binding</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">v1.1.0, <time class="dt-updated" datetime="2019-05-28">28 May 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2019-05-28">28 May 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1533,7 +1533,7 @@ pre .property::before, pre .property::after {
     <li data-md>
      <p>It SHOULD indicate a structural ISOBMFF brand among the compatible brands array of the FileTypeBox, such as <a class="property" data-link-type="propdesc" href="https://www.iso.org/standard/68960.html#" id="termref-for-">iso6</a></p>
     <li data-md>
-     <p>It MAY indicate CMAF brands as specified in <a href="#cmaf">§3 CMAF AV1 track format</a></p>
+     <p>It MAY indicate CMAF brands as specified in <a href="#cmaf">§ 3 CMAF AV1 track format</a></p>
     <li data-md>
      <p>It MAY indicate other brands not specified in this document provided that the associated requirements do not conflict with those given in this specification</p>
    </ul>
@@ -1780,7 +1780,7 @@ Quantity:   Zero or more.
        <p><code>initial_presentation_delay_minus_one</code></p>
      </ul>
    </ul>
-   <p>When protected, <a data-link-type="dfn" href="#cmaf-av1-track" id="ref-for-cmaf-av1-track">CMAF AV1 Tracks</a> SHALL use the signaling defined in <a data-link-type="biblio" href="#biblio-cmaf">[CMAF]</a>, which in turn relies on <a data-link-type="biblio" href="#biblio-cenc">[CENC]</a>, with the provisions specified in <a href="#CommonEncryption">§4 Common Encryption</a>.</p>
+   <p>When protected, <a data-link-type="dfn" href="#cmaf-av1-track" id="ref-for-cmaf-av1-track">CMAF AV1 Tracks</a> SHALL use the signaling defined in <a data-link-type="biblio" href="#biblio-cmaf">[CMAF]</a>, which in turn relies on <a data-link-type="biblio" href="#biblio-cenc">[CENC]</a>, with the provisions specified in <a href="#CommonEncryption">§ 4 Common Encryption</a>.</p>
    <h2 class="heading settled" data-level="4" id="CommonEncryption"><span class="secno">4. </span><span class="content">Common Encryption</span><a class="self-link" href="#CommonEncryption"></a></h2>
    <p><a data-link-type="dfn" href="#cmaf-av1-track" id="ref-for-cmaf-av1-track①">CMAF AV1 Tracks</a> and non-segmented AV1 files MAY be protected. If protected, they SHALL conform to <a data-link-type="biblio" href="#biblio-cenc">[CENC]</a>. Files SHOULD be protected using the <code><a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-②①">cbcs</a></code> protection scheme and MAY be protected using the <code><a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-②②">cenc</a></code> protection scheme.</p>
    <p>When the protected scheme <code><a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-②③">cenc</a></code> is used, samples SHALL be protected using subsample encryption and SHALL NOT use pattern encryption.</p>
@@ -1800,7 +1800,7 @@ Quantity:   Zero or more.
      <p>Protected samples SHALL be exactly spanned by one or more contiguous subsamples.</p>
      <ul>
       <li data-md>
-       <p>An OBU MAY be spanned by one or more subsamples, especially when it has multiple ranges of protected data. However, as recommended in <a data-link-type="biblio" href="#biblio-cenc">[CENC]</a>, writers SHOULD reduce the number of subsamples as possible. This can be achieved by using a subsample that spans multiple consecutive unprotected OBUs as well as the first unprotected and protected parts of the following protected OBU, if such protected OBU exists.</p>
+       <p>An OBU MAY be spanned by one or more subsamples, especially when it has multiple ranges of protected data, e.g. when tiles are used. However, as recommended in <a data-link-type="biblio" href="#biblio-cenc">[CENC]</a>, writers SHOULD reduce the number of subsamples as possible. This can be achieved by using a subsample that spans multiple consecutive unprotected OBUs as well as the first unprotected and protected parts of the following protected OBU, if such protected OBU exists.</p>
       <li data-md>
        <p>A large unprotected OBU whose data size is larger than the maximum size of a single <a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-②⑤">BytesOfClearData</a> field MAY be spanned by multiple subsamples with zero size <a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-②⑥">BytesOfProtectedData</a>.</p>
      </ul>
@@ -1816,14 +1816,20 @@ Quantity:   Zero or more.
       <li data-md>
        <p><a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-②⑦">BytesOfProtectedData</a> SHALL be a multiple of 16 bytes.</p>
       <li data-md>
-       <p><a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-②⑧">BytesOfProtectedData</a> SHALL end on the last byte of the <code>decode_tile</code> structure (including any trailing bits).</p>
+       <p><a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-②⑧">BytesOfProtectedData</a> SHALL:</p>
+       <ul>
+        <li data-md>
+         <p>end on the last byte of the <code>decode_tile</code> structure (including any trailing bits), when the protected scheme is either <code><a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-②⑨">cenc</a></code> or <code><a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-③⓪">cbcs</a></code>,</p>
+        <li data-md>
+         <p>or start on the first byte of the <code>decode_tile</code> structure, when the protected scheme is <code><a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-③①">cbcs</a></code></p>
+       </ul>
       <li data-md>
-       <p><a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-②⑨">BytesOfProtectedData</a> SHALL span all complete 16-byte blocks of the <code>decode_tile</code> structure (including any trailing bits).</p>
+       <p><a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-③②">BytesOfProtectedData</a> SHALL span all complete 16-byte blocks of the <code>decode_tile</code> structure (including any trailing bits if end alignment is used when the protected scheme is <code><a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-③③">cbcs</a></code>).</p>
      </ul>
-     <p class="note" role="note"><span>NOTE:</span> As a result of the above, partial blocks are not used and it is possible that <a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-③⓪">BytesOfProtectedData</a> does not start at the first byte of the <code>decode_tile</code> structure, but some number of bytes following that.</p>
+     <p class="note" role="note"><span>NOTE:</span> As a result of the above, partial blocks are not used and it is possible that <a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-③④">BytesOfProtectedData</a> does not start at the first byte of the <code>decode_tile</code> structure, but some number of bytes following that.</p>
      <ul>
       <li data-md>
-       <p>A subsample SHALL be created for each tile that has a <code>decode_tile</code> structure whose size (including any trailing bits) is larger or equal to 16 bytes. If it is less than 16 bytes, per the rules above, the <code>decode_tile</code> structure is not encrypted and the corresponding bytes SHOULD be included in the <a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-③①">BytesOfClearData</a> field of a surrounding subsample, if any.</p>
+       <p>A subsample SHALL be created for each tile that has a <code>decode_tile</code> structure whose size (including any trailing bits) is larger or equal to 16 bytes. If it is less than 16 bytes, per the rules above, the <code>decode_tile</code> structure is not encrypted and the corresponding bytes SHOULD be included in the <a data-link-type="dfn" href="https://www.iso.org/standard/68042.html#" id="termref-for-③⑤">BytesOfClearData</a> field of a surrounding subsample, if any.</p>
       <li data-md>
        <p>All other parts of <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71⑤">Tile Group OBUs</a> and <a data-link-type="dfn" href="https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=71" id="ref-for-page=71⑥">Frame OBUs</a> SHALL be unprotected.</p>
      </ul>
@@ -1835,7 +1841,7 @@ Quantity:   Zero or more.
     <figcaption>Subsample-based AV1 encryption.</figcaption>
    </figure>
    <h2 class="heading settled" data-level="5" id="codecsparam"><span class="secno">5. </span><span class="content">Codecs Parameter String</span><a class="self-link" href="#codecsparam"></a></h2>
-   <p>DASH and other applications require defined values for the <a class="property" data-link-type="propdesc" href="https://tools.ietf.org/html/rfc6381#" id="termref-for-③②">Codecs</a> parameter specified in <a data-link-type="biblio" href="#biblio-rfc6381">[RFC6381]</a> for ISO Media tracks. The codecs parameter string for the AOM AV1 codec is as follows:</p>
+   <p>DASH and other applications require defined values for the <a class="property" data-link-type="propdesc" href="https://tools.ietf.org/html/rfc6381#" id="termref-for-③⑥">Codecs</a> parameter specified in <a data-link-type="biblio" href="#biblio-rfc6381">[RFC6381]</a> for ISO Media tracks. The codecs parameter string for the AOM AV1 codec is as follows:</p>
 <pre>&lt;sample entry 4CC>.&lt;profile>.&lt;level>&lt;tier>.&lt;bitDepth>.&lt;monochrome>.&lt;chromaSubsampling>.
 &lt;colorPrimaries>.&lt;transferCharacteristics>.&lt;matrixCoefficients>.&lt;videoFullRangeFlag>
 </pre>
@@ -2433,28 +2439,28 @@ Quantity:   Zero or more.
    <a href="https://www.iso.org/standard/68042.html#">https://www.iso.org/standard/68042.html#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">4. Common Encryption</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
-    <li><a href="#termref-for-">4.1. General Subsample Encryption constraints</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">4.1. General Subsample Encryption constraints</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a> <a href="#termref-for-">(10)</a> <a href="#termref-for-">(11)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
    <a href="https://www.iso.org/standard/68042.html#">https://www.iso.org/standard/68042.html#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">4. Common Encryption</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
-    <li><a href="#termref-for-">4.1. General Subsample Encryption constraints</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">4.1. General Subsample Encryption constraints</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a> <a href="#termref-for-">(10)</a> <a href="#termref-for-">(11)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
    <a href="https://www.iso.org/standard/68042.html#">https://www.iso.org/standard/68042.html#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">4. Common Encryption</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
-    <li><a href="#termref-for-">4.1. General Subsample Encryption constraints</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">4.1. General Subsample Encryption constraints</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a> <a href="#termref-for-">(10)</a> <a href="#termref-for-">(11)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">
    <a href="https://www.iso.org/standard/68042.html#">https://www.iso.org/standard/68042.html#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">4. Common Encryption</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
-    <li><a href="#termref-for-">4.1. General Subsample Encryption constraints</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a>
+    <li><a href="#termref-for-">4.1. General Subsample Encryption constraints</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a> <a href="#termref-for-">(5)</a> <a href="#termref-for-">(6)</a> <a href="#termref-for-">(7)</a> <a href="#termref-for-">(8)</a> <a href="#termref-for-">(9)</a> <a href="#termref-for-">(10)</a> <a href="#termref-for-">(11)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-">


### PR DESCRIPTION
For review during next conf call on Sept 4th.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-isobmff/pull/117.html" title="Last updated on Aug 30, 2019, 4:12 PM UTC (662178c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-isobmff/117/8a2e4cf...662178c.html" title="Last updated on Aug 30, 2019, 4:12 PM UTC (662178c)">Diff</a>