### PR TITLE
Rename the changelist section for the next version

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -644,8 +644,5 @@ The string codecs="av01.0.01M.08" in this case would represent AV1 Main Profile,
 
 If any character that is not '.', digits, part of the AV1 4CC, or a tier value is encountered, the string SHALL be interpreted ignoring all the characters starting from that character.
 
-Changes since v1.1.0 release {#changelist}
+Changes since v1.2.0 release {#changelist}
 ==========================================
-- <a href="https://github.com/AOMediaCodec/av1-isobmff/pull/116"> Change tile/subsample alignement for the <code>cbcs</code> protection scheme.</a>
-
-


### PR DESCRIPTION
The changelist section "Changes since v1.1.0 release" is renamed
"Changes since v1.2.0 release".

Fix https://github.com/AOMediaCodec/av1-isobmff/issues/143.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wantehchang/av1-isobmff/pull/144.html" title="Last updated on May 2, 2022, 4:28 PM UTC (11d4363)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-isobmff/144/be8adcc...wantehchang:11d4363.html" title="Last updated on May 2, 2022, 4:28 PM UTC (11d4363)">Diff</a>