### PR TITLE
wrapping normative statements with assert elements

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -179,12 +179,12 @@ General Requirements & Brands {#brands}
 -----------------------------
 
 A file conformant to this specification satisfies the following:
-- It SHALL conform to the normative requirements of [[!ISOBMFF]]
-- It SHALL have the <dfn value export for="ISOBMFF Brand">av01</dfn> brand among the compatible brands array of the FileTypeBox
-- It SHALL contain at least one track using an [=AV1SampleEntry=]
-- It SHOULD indicate a structural ISOBMFF brand among the compatible brands array of the FileTypeBox, such as 'iso6'
-- It MAY indicate CMAF brands as specified in [[#cmaf]]
-- It MAY indicate other brands not specified in this document provided that the associated requirements do not conflict with those given in this specification
+- <assert>It SHALL conform to the normative requirements of [[!ISOBMFF]]</assert>
+- <assert>It SHALL have the <dfn value export for="ISOBMFF Brand">av01</dfn> brand among the compatible brands array of the FileTypeBox</assert>
+- <assert>It SHALL contain at least one track using an [=AV1SampleEntry=]</assert>
+- <assert>It SHOULD indicate a structural ISOBMFF brand among the compatible brands array of the FileTypeBox, such as 'iso6'</assert>
+- <assert>It MAY indicate CMAF brands as specified in [[#cmaf]]</assert>
+- <assert>It MAY indicate other brands not specified in this document provided that the associated requirements do not conflict with those given in this specification</assert>
 
 Parsers SHALL support the structures required by the <code>'iso6'</code> brand and MAY support structures required by further ISOBMFF structural brands.
 
@@ -196,8 +196,8 @@ AV1 Sample Entry {#av1sampleentry-section}
 <pre class="def">
 	Sample Entry Type: <dfn value export for="AV1SampleEntry">av01</dfn>
 	Container:         Sample Description Box ('stsd')
-	Mandatory:         Yes
-	Quantity:          One or more.
+	Mandatory:         <assert>Yes</assert>
+	Quantity:          <assert>One or more.</assert>
 </pre>
 
 ### Description ### {#av1sampleentry-description}
@@ -214,26 +214,26 @@ class AV1SampleEntry extends VisualSampleEntry('av01') {
 
 ### Semantics ### {#av1sampleentry-semantics}
 
-The <dfn noexport>width</dfn> and <dfn noexport>height</dfn> fields of the [=VisualSampleEntry=] SHALL equal the values of [=max_frame_width_minus_1=] + 1 and [=max_frame_height_minus_1=] + 1 of the [=Sequence Header OBU=] applying to the samples associated with this sample entry.
+<assert>The <dfn noexport>width</dfn> and <dfn noexport>height</dfn> fields of the [=VisualSampleEntry=] SHALL equal the values of [=max_frame_width_minus_1=] + 1 and [=max_frame_height_minus_1=] + 1 of the [=Sequence Header OBU=] applying to the samples associated with this sample entry.</assert>
 
 Let MaxRenderWidth be the maximum RenderWidth and MaxRenderHeight be the maximum RenderHeight of all the frames in the track.
-The width and height in the TrackHeaderBox SHOULD be equal to MaxRenderWidth and MaxRenderHeight, respectively.
-Additionally, if MaxRenderWidth and MaxRenderHeight values do not equal respectively the [=max_frame_width_minus_1=] + 1 and [=max_frame_height_minus_1=] + 1 values of the [=Sequence Header OBU=], a PixelAspectRatioBox box SHALL be present in the sample entry and set such that:
+<assert>The width and height in the TrackHeaderBox SHOULD be equal to MaxRenderWidth and MaxRenderHeight, respectively.</assert>
+<assert>Additionally, if MaxRenderWidth and MaxRenderHeight values do not equal respectively the [=max_frame_width_minus_1=] + 1 and [=max_frame_height_minus_1=] + 1 values of the [=Sequence Header OBU=], a PixelAspectRatioBox box SHALL be present in the sample entry and set such that</assert>:
 
 ```
 hSpacing / vSpacing = MaxRenderWidth * (max_frame_height_minus_1 + 1) /
                               ((max_frame_width_minus_1 + 1) * MaxRenderHeight)
 ```
 
-The <dfn noexport>compressorname</dfn> field of the [=VisualSampleEntry=] is an informative name. It is formatted in a fixed 32-byte field, with the first byte set to the number of bytes to be displayed, followed by that number of bytes of displayable data, followed by padding to complete 32 bytes total (including the size byte). The value "\012AOM Coding" is RECOMMENDED; the first byte is a count of the remaining bytes, here represented by \012, which (being octal 12) is decimal 10, the number of bytes in the rest of the string.
+The <dfn noexport>compressorname</dfn> field of the [=VisualSampleEntry=] is an informative name. It is formatted in a fixed 32-byte field, with the first byte set to the number of bytes to be displayed, followed by that number of bytes of displayable data, followed by padding to complete 32 bytes total (including the size byte). <assert>The value "\012AOM Coding" is RECOMMENDED</assert>; the first byte is a count of the remaining bytes, here represented by \012, which (being octal 12) is decimal 10, the number of bytes in the rest of the string.
 
 NOTE: Parsers may ignore the value of the compressorname field. It is specified in this document simply for legacy and backwards compatibility reasons.
 
-The <dfn noexport>config</dfn> field SHALL contain an [=AV1CodecConfigurationBox=] that applies to the samples associated with this sample entry.
+<assert>The <dfn noexport>config</dfn> field SHALL contain an [=AV1CodecConfigurationBox=] that applies to the samples associated with this sample entry.</assert>
 
-NOTE: Multiple instances of [=AV1SampleEntry=] may be required when the track contains samples requiring a [=AV1CodecConfigurationBox=] with different characteristics.
+NOTE: <assert>Multiple instances of [=AV1SampleEntry=] may be required when the track contains samples requiring a [=AV1CodecConfigurationBox=] with different characteristics.</assert>
 
-Optional boxes not specifically mentioned here can be present, in particular those indicated in the definition of the [=VisualSampleEntry=] in [[ISOBMFF]].
+<assert>Optional boxes not specifically mentioned here can be present, in particular those indicated in the definition of the [=VisualSampleEntry=] in [[ISOBMFF]].</assert>
 
 AV1 Codec Configuration Box {#av1codecconfigurationbox-section}
 --------------------------------------------------------
@@ -243,14 +243,14 @@ AV1 Codec Configuration Box {#av1codecconfigurationbox-section}
 <pre class="def">
 	Box Type:  <dfn export>av1C</dfn>
 	Container: AV1 Sample Entry ('av01')
-	Mandatory: Yes
-	Quantity:  Exactly One
+	Mandatory: <assert>Yes</assert>
+	Quantity:  <assert>Exactly One</assert>
 </pre>
 
 
 ### Description ### {#av1codecconfigurationbox-description}
 
-The <dfn>AV1CodecConfigurationBox</dfn> contains decoder configuration information that SHALL be valid for every sample that references the sample entry.
+<assert>The <dfn>AV1CodecConfigurationBox</dfn> contains decoder configuration information that SHALL be valid for every sample that references the sample entry.</assert>
 
 
 ### Syntax ### {#av1codecconfigurationbox-syntax}
@@ -287,21 +287,21 @@ aligned (8) class AV1CodecConfigurationRecord {
 
 ### Semantics ### {#av1codecconfigurationbox-semantics}
 
-The <dfn export>marker</dfn> field SHALL be set to 1.
+<assert>The <dfn export>marker</dfn> field SHALL be set to 1.</assert>
 
 NOTE: The marker bit ensures that the bit pattern of the first byte of the AV1CodecConfigurationRecord cannot be mistaken for an [=OBU Header=] byte.
 
-The <dfn noexport>version</dfn> field indicates the version of the AV1CodecConfigurationRecord. The value SHALL be set to 1 for AV1CodecConfigurationRecord.
+The <dfn noexport>version</dfn> field indicates the version of the AV1CodecConfigurationRecord. <assert>The value SHALL be set to 1 for AV1CodecConfigurationRecord</assert>.
 
-The <dfn export>seq_profile</dfn> field indicates the AV1 profile and SHALL be equal to the seq_profile value from the [=Sequence Header OBU=].
+<assert>The <dfn export>seq_profile</dfn> field indicates the AV1 profile and SHALL be equal to the seq_profile value from the [=Sequence Header OBU=].</assert>
 
-The <dfn export>seq_level_idx_0</dfn> field indicates the value of seq_level_idx[0] found in the [=Sequence Header OBU=] and SHALL be equal to the value of seq_level_idx[0] in the [=Sequence Header OBU=].
+<assert>The <dfn export>seq_level_idx_0</dfn> field indicates the value of seq_level_idx[0] found in the [=Sequence Header OBU=] and SHALL be equal to the value of seq_level_idx[0] in the [=Sequence Header OBU=]</assert>.
 
-The <dfn export>seq_tier_0</dfn> field indicates the value of seq_tier[0] found in the [=Sequence Header OBU=] and SHALL be equal to the value of seq_tier[0] in the [=Sequence Header OBU=].
+<assert>The <dfn export>seq_tier_0</dfn> field indicates the value of seq_tier[0] found in the [=Sequence Header OBU=] and SHALL be equal to the value of seq_tier[0] in the [=Sequence Header OBU=]</assert>.
 
 The <dfn export>high_bitdepth</dfn> field indicates the value of the [=high_bitdepth=] flag from the [=Sequence Header OBU=].
 
-The <dfn export>twelve_bit</dfn> field indicates the value of the [=twelve_bit=] flag from the [=Sequence Header OBU=]. When twelve_bit is not present in the [=Sequence Header OBU=] the AV1CodecConfigurationRecord twelve_bit value SHALL be 0.
+The <dfn export>twelve_bit</dfn> field indicates the value of the [=twelve_bit=] flag from the [=Sequence Header OBU=]. <assert>When twelve_bit is not present in the [=Sequence Header OBU=] the AV1CodecConfigurationRecord twelve_bit value SHALL be 0.</assert>
 
 The <dfn export>monochrome</dfn> field indicates the value of the [=mono_chrome=] flag from the [=Sequence Header OBU=].
 
@@ -311,11 +311,11 @@ The <dfn export>chroma_subsampling_y</dfn> field indicates the [=subsampling_y=]
 
 The <dfn export>chroma_sample_position</dfn> field indicates the [=chroma_sample_position=] value from the [=Sequence Header OBU=].
 
-When not specified in the [=Sequence Header OBU=], and not defined by the conditions specified in the [[!AV1]] [=color_config=], the values of [=chroma_subsampling_x=], [=chroma_subsampling_y=], and [=chroma_sample_position=] SHALL be 0.
+<assert>When not specified in the [=Sequence Header OBU=], and not defined by the conditions specified in the [[!AV1]] [=color_config=], the values of [=chroma_subsampling_x=], [=chroma_subsampling_y=], and [=chroma_sample_position=] SHALL be 0.</assert>
 
 The <dfn export>initial_presentation_delay_present</dfn> field indicates the presence of the initial_presentation_delay_minus_one field.
 
-The <dfn>initial_presentation_delay_minus_one</dfn> field indicates the number of samples (minus one) that need to be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by [=seq_level_idx=] in the [=Sequence Header OBU=] (in the configOBUs field or in the associated samples). More precisely, the following procedure SHALL not return any error:
+The <dfn>initial_presentation_delay_minus_one</dfn> field indicates the number of samples (minus one) that need to be decoded prior to starting the presentation of the first sample associated with this sample entry in order to guarantee that each sample will be decoded prior to its presentation time under the constraints of the first level value indicated by [=seq_level_idx=] in the [=Sequence Header OBU=] (in the configOBUs field or in the associated samples). More precisely, <assert>the following procedure SHALL not return any error</assert>:
 - construct a hypothetical bitstream consisting of the OBUs carried in the sample entry followed by the OBUs carried in all the samples referring to that sample entry,
 - set the first [=initial_display_delay_minus_1=] field of each [=Sequence Header OBU=] to the number of frames minus one contained in the first [=initial_presentation_delay_minus_one=] + 1 samples,
 - set the [=frame_presentation_time=] field of the frame header of each presentable frame such that it matches the presentation time difference between the sample carrying this frame and the previous sample (if it exists, 0 otherwise),
@@ -342,44 +342,44 @@ But if the frames were grouped as follows:
 <code>[=initial_presentation_delay_minus_one=]</code> would be 2 because it takes presentation of 3 samples to ensure that <code>c</code> is decoded.
 </div>
 
-The <dfn export>configOBUs</dfn> field contains zero or more OBUs. Any OBU may be present provided that the following procedures produce compliant AV1 bitstreams:
-- From any sync sample, an AV1 bitstream is formed by first outputting the OBUs contained in the [=AV1CodecConfigurationBox=] and then by outputing all OBUs in the samples themselves, in order, starting from the sync sample.
-- From any sample marked with the [=AV1ForwardKeyFrameSampleGroupEntry=], an AV1 bitstream is formed by first outputting the OBUs contained in the [=AV1CodecConfigurationBox=] and then by outputing all OBUs in the sample itself, then by outputting all OBUs in the samples, in order, starting from the sample at the distance indicated by the sample group.
+<assert>The <dfn export>configOBUs</dfn> field contains zero or more OBUs</assert>. Any OBU may be present provided that the following procedures produce compliant AV1 bitstreams:
+- <assert>From any sync sample, an AV1 bitstream is formed by first outputting the OBUs contained in the [=AV1CodecConfigurationBox=] and then by outputing all OBUs in the samples themselves, in order, starting from the sync sample.</assert>
+- <assert>From any sample marked with the [=AV1ForwardKeyFrameSampleGroupEntry=], an AV1 bitstream is formed by first outputting the OBUs contained in the [=AV1CodecConfigurationBox=] and then by outputing all OBUs in the sample itself, then by outputting all OBUs in the samples, in order, starting from the sample at the distance indicated by the sample group.</assert>
 
-Additionally, the configOBUs field SHALL contain at most one [=Sequence Header OBU=] and if present, it SHALL be the first OBU.
+Additionally, <assert>the configOBUs field SHALL contain at most one [=Sequence Header OBU=]</assert> and if present, <assert>it SHALL be the first OBU</assert>.
 
 NOTE: The configOBUs field is expected to contain only one [=Sequence Header OBU=] and zero or more [=Metadata OBUs=] when applicable to all the associated samples.
 
-OBUs stored in the configOBUs field follow the [=open_bitstream_unit=] [=Low Overhead Bitstream Format=] syntax as specified in [[!AV1]]. The flag [=obu_has_size_field=] SHALL be set to 1, indicating that the size of the OBU payload follows the header, and that it is coded using LEB128.
+OBUs stored in the configOBUs field follow the [=open_bitstream_unit=] [=Low Overhead Bitstream Format=] syntax as specified in [[!AV1]]. <assert>The flag [=obu_has_size_field=] SHALL be set to 1, indicating that the size of the OBU payload follows the header, and that it is coded using LEB128</assert>.
 
-When a [=Sequence Header OBU=] is contained within the configOBUs of the AV1CodecConfigurationRecord, the values present in the [=Sequence Header OBU=] contained within configOBUs SHALL match the values of the AV1CodecConfigurationRecord.
+<assert>When a [=Sequence Header OBU=] is contained within the configOBUs of the AV1CodecConfigurationRecord, the values present in the [=Sequence Header OBU=] contained within configOBUs SHALL match the values of the AV1CodecConfigurationRecord.</assert>
 
-The presentation times of AV1 samples are given by the ISOBMFF structures. The [=timing_info_present_flag=] in the [=Sequence Header OBU=] (in the configOBUs field or in the associated samples) SHOULD be set to 0. If set to 1, the [=timing_info=] structure of the [=Sequence Header OBU=], the [=frame_presentation_time=] and [=buffer_removal_time=] fields of the [=Frame Header OBUs=], if present, SHALL be ignored for the purpose of timed processing of the ISOBMFF file.
+The presentation times of AV1 samples are given by the ISOBMFF structures. <assert>The [=timing_info_present_flag=] in the [=Sequence Header OBU=] (in the configOBUs field or in the associated samples) SHOULD be set to 0</assert>. If set to 1, the [=timing_info=] structure of the [=Sequence Header OBU=], the [=frame_presentation_time=] and [=buffer_removal_time=] fields of the [=Frame Header OBUs=], if present, SHALL be ignored for the purpose of timed processing of the ISOBMFF file.
 
-The sample entry SHOULD contain a 'colr' box with a colour_type set to 'nclx'. If present, the values of colour_primaries, transfer_characteristics, and matrix_coefficients SHALL match the values given in the [=Sequence Header OBU=] (in the configOBUs field or in the associated samples) if the color_description_present_flag is set to 1. Similarly, the full_range_flag in the 'colr' box shall match the color_range flag in the [=Sequence Header OBU=]. When configOBUs does not contain a [=Sequence Header OBU=], this box with colour_type set to 'nclx' SHALL be present.
+<assert>The sample entry SHOULD contain a 'colr' box with a colour_type set to 'nclx'</assert>. <assert>If present, the values of colour_primaries, transfer_characteristics, and matrix_coefficients SHALL match the values given in the [=Sequence Header OBU=] (in the configOBUs field or in the associated samples) if the color_description_present_flag is set to 1</assert>. Similarly, <assert>the full_range_flag in the 'colr' box shall match the color_range flag in the [=Sequence Header OBU=]</assert>. <assert>When configOBUs does not contain a [=Sequence Header OBU=], this box with colour_type set to 'nclx' SHALL be present.</assert>
 
-The CleanApertureBox 'clap' SHOULD not be present.
+<assert>The CleanApertureBox 'clap' SHOULD not be present.</assert>
 
-For sample entries corresponding to HDR content, the MasteringDisplayColourVolumeBox 'mdcv' and ContentLightLevelBox 'clli' SHOULD be present, and their values SHALL match the values contained in the [=Metadata OBUs=] of type METADATA_TYPE_HDR_CLL and METADATA_TYPE_HDR_MDCV, if present (in the configOBUs or in the samples).
+<assert>For sample entries corresponding to HDR content, the MasteringDisplayColourVolumeBox 'mdcv' and ContentLightLevelBox 'clli' SHOULD be present</assert>, and <assert>their values SHALL match the values contained in the [=Metadata OBUs=] of type METADATA_TYPE_HDR_CLL and METADATA_TYPE_HDR_MDCV, if present (in the configOBUs or in the samples)</assert>.
 
 NOTE: The MasteringDisplayColourVolumeBox 'mdcv' and ContentLightLevelBox 'clli' have identical syntax to the SMPTE2086MasteringDisplayMetadataBox 'SmDm' and ContentLightLevelBox 'CoLL', except that they are of type <code>Box</code> and not <code>FullBox</code>. However, the semantics of the MasteringDisplayColourVolumeBox and SMPTE2086MasteringDisplayMetadataBox have important differences and should not be confused.
 
-Additional boxes may be provided at the end of the [=VisualSampleEntry=] as permitted by ISOBMFF, that may represent redundant or similar information to the one provided in some OBUs contained in the [=AV1CodecConfigurationBox=]. If the box definition does not indicate that its information overrides the OBU information, in case of conflict, the OBU information should be considered authoritative.
+<assert>Additional boxes may be provided at the end of the [=VisualSampleEntry=] as permitted by ISOBMFF, that may represent redundant or similar information to the one provided in some OBUs contained in the [=AV1CodecConfigurationBox=]</assert>. If the box definition does not indicate that its information overrides the OBU information, in case of conflict, the OBU information should be considered authoritative.
 
 AV1 Sample Format {#sampleformat}
 ---------------------------------
 
 For tracks using the [=AV1SampleEntry=], an <dfn>AV1 Sample</dfn> has the following constraints:
-- the sample data SHALL be a sequence of [=OBUs=] forming a [=Temporal Unit=],
-- each OBU SHALL follow the [=open_bitstream_unit=] [=Low Overhead Bitstream Format=] syntax as specified in [[!AV1]]. Each OBU SHALL have the [=obu_has_size_field=] set to 1 except for the last OBU in the sample, for which [=obu_has_size_field=] MAY be set to 0, in which case it is assumed to fill the remainder of the sample,
+- <assert>the sample data SHALL be a sequence of [=OBUs=] forming a [=Temporal Unit=]</assert>,
+- <assert>each OBU SHALL follow the [=open_bitstream_unit=] [=Low Overhead Bitstream Format=] syntax as specified in [[!AV1]]</assert>. <assert>Each OBU SHALL have the [=obu_has_size_field=] set to 1 except for the last OBU in the sample</assert>, for which <assert>[=obu_has_size_field=] MAY be set to 0, in which case it is assumed to fill the remainder of the sample</assert>,
 
 NOTE: When extracting OBUs from an ISOBMFF file, and depending on the capabilities of the decoder processing these OBUs, ISOBMFF parsers MAY need to either: set the [=obu_has_size_field=] to 1 for some OBUs if not already set, add the size field in this case, and add [=Temporal Delimiter OBU=]; or use the length-delimited bitstream format as defined in Annex B of [=AV1=]. If encryption is used, similar operations MAY have to be done before or after decryption depending on the demuxer/decryptor/decoder architecture.
 
-- OBU trailing bits SHOULD be limited to byte alignment and SHOULD not be used for padding,
-- OBUs of type OBU_TEMPORAL_DELIMITER, OBU_PADDING, or OBU_REDUNDANT_FRAME_HEADER SHOULD NOT be used.
-- OBUs of type OBU_TILE_LIST SHALL NOT be used.
+- <assert>OBU trailing bits SHOULD be limited to byte alignment and SHOULD not be used for padding</assert>,
+- <assert>OBUs of type OBU_TEMPORAL_DELIMITER, OBU_PADDING, or OBU_REDUNDANT_FRAME_HEADER SHOULD NOT be used</assert>.
+- <assert>OBUs of type OBU_TILE_LIST SHALL NOT be used</assert>.
 
-If an AV1 Sample is signaled as a sync sample (in the SyncSampleBox or by setting sample_is_non_sync_sample to 0), it SHALL be a Random Access Point as defined in [[!AV1]], i.e. satisfy the following constraints:
+<assert>If an AV1 Sample is signaled as a sync sample (in the SyncSampleBox or by setting sample_is_non_sync_sample to 0), it SHALL be a Random Access Point as defined in [[!AV1]]</assert>, i.e. satisfy the following constraints:
 - Its first frame is a [=Key Frame=] that has [=show_frame=] flag set to 1,
 - It contains a [=Sequence Header OBU=] before the first [=Frame Header OBU=].
 
@@ -387,19 +387,19 @@ NOTE: Within this definition, a sync sample may contain additional frames that a
 
 NOTE: Other types of OBUs such as [=metadata OBUs=] could be present before the [=Sequence Header OBU=].
 
-[=Intra-only frames=] SHOULD be signaled using the sample_depends_on flag set to 2.
+<assert>[=Intra-only frames=] SHOULD be signaled using the sample_depends_on flag set to 2</assert>.
 
-[=Delayed Random Access Points=] SHOULD be signaled using sample groups and the [=AV1ForwardKeyFrameSampleGroupEntry=].
+<assert>[=Delayed Random Access Points=] SHOULD be signaled using sample groups and the [=AV1ForwardKeyFrameSampleGroupEntry=]</assert>.
 
-[=Switch Frames=] SHOULD be signaled using sample groups and the [=AV1SwitchFrameSampleGroupEntry=].
+<assert>[=Switch Frames=] SHOULD be signaled using sample groups and the [=AV1SwitchFrameSampleGroupEntry=]</assert>.
 
-Additionally, if a file contains multiple tracks that are alternative representations of the same content, in particular using [=Switch Frames=], those tracks SHOULD be marked as belonging to the same alternate group and should use a track selection box with an appropriate attribute (e.g. 'bitr').
+Additionally, <assert>if a file contains multiple tracks that are alternative representations of the same content, in particular using [=Switch Frames=], those tracks SHOULD be marked as belonging to the same alternate group</assert> and <assert>should use a track selection box with an appropriate attribute (e.g. 'bitr')</assert>.
 
-In tracks using the [=AV1SampleEntry=], the 'ctts' box and composition offsets in movie fragments SHALL NOT be used. Similarly, the is_leading flag, if used, SHALL be set to 0 or 2.
+<assert>In tracks using the [=AV1SampleEntry=], the 'ctts' box and composition offsets in movie fragments SHALL NOT be used</assert>. Similarly, <assert>the is_leading flag, if used, SHALL be set to 0 or 2</assert>.
 
-When a temporal unit contains more than one frame, the sample corresponding to that temporal unit MAY be marked using the [=AV1MultiFrameSampleGroupEntry=].
+<assert>When a temporal unit contains more than one frame, the sample corresponding to that temporal unit MAY be marked using the [=AV1MultiFrameSampleGroupEntry=]</assert>.
 
-[=Metadata OBUs=] may be carried in sample data. In this case, the [=AV1MetadataSampleGroupEntry=] SHOULD be used. If the [=metadata OBUs=] are static for the entire set of samples associated with a given sample description entry, they SHOULD also be in the OBU array in the sample description entry.
+<assert>[=Metadata OBUs=] may be carried in sample data</assert>. In this case, <assert>the [=AV1MetadataSampleGroupEntry=] SHOULD be used</assert>. <assert>If the [=metadata OBUs=] are static for the entire set of samples associated with a given sample description entry, they SHOULD also be in the OBU array in the sample description entry</assert>.
 
 Unless explicitely stated, the grouping_type_parameter is not defined for the SampleToGroupBox with grouping types defined in this specification.
 
@@ -411,8 +411,8 @@ AV1 Forward Key Frame sample group entry {#forwardkeyframesamplegroupentry}
 <pre class="def">
 	Group Type: <dfn export>av1f</dfn>
 	Container:  Sample Group Description Box ('sgpd')
-	Mandatory:  No
-	Quantity:   Zero or more.
+	Mandatory:  <assert>No</assert>
+	Quantity:   <assert>Zero or more</assert>.
 </pre>
 
 ### Description ### {#forwardkeyframesamplegroupentry-description}
@@ -440,8 +440,8 @@ AV1 Multi-Frame sample group entry {#multiframesamplegroupentry}
 <pre class="def">
 	Group Type: <dfn value export for="AV1MultiFrameSampleGroupEntry">av1m</dfn>
 	Container:  Sample Group Description Box ('sgpd')
-	Mandatory:  No
-	Quantity:   Zero or more.
+	Mandatory:  <assert>No</assert>
+	Quantity:   <assert>Zero or more</assert>.
 </pre>
 
 
@@ -465,8 +465,8 @@ AV1 Switch Frame sample group entry {#switchframesamplegroupentry}
 <pre class="def">
 	Group Type: <dfn export>av1s</dfn>
 	Container:  Sample Group Description Box ('sgpd')
-	Mandatory:  No
-	Quantity:   Zero or more.
+	Mandatory:  <assert>No</assert>
+	Quantity:   <assert>Zero or more</assert>.
 </pre>
 
 
@@ -489,8 +489,8 @@ AV1 Metadata sample group entry {#metadatasamplegroupentry}
 <pre class="def">
 	Group Type: <dfn value noexport for="AV1MetadataSampleGroupEntry">av1M</dfn>
 	Container:  Sample Group Description Box ('sgpd')
-	Mandatory:  No
-	Quantity:   Zero or more.
+	Mandatory:  <assert>No</assert>
+	Quantity:   <assert>Zero or more</assert>.
 </pre>
 
 
@@ -526,8 +526,8 @@ CMAF AV1 track format {#cmaf}
 [[CMAF]] defines structural constraints on ISOBMFF files additional to [[ISOBMFF]] for the purpose of, for example, adaptive streaming or for protected files. Conformance to these structural constraints is signaled by the presence of the brand <code>[=cmfc=]</code> in the <code>FileTypeBox</code>.
 
 If a [=CMAF Video Track=] uses the brand <code>av01</code>, it is called a <dfn>CMAF AV1 Track</dfn> and the following constraints, defining the CMAF Media Profile for AV1, apply:
-- it SHALL use an [=AV1SampleEntry=]
-- it MAY use multiple sample entries, and in that case the following values SHALL not change in the track:
+- <assert>it SHALL use an [=AV1SampleEntry=]</assert>
+- <assert>it MAY use multiple sample entries, and in that case the following values SHALL not change in the track</assert>:
     - <code>seq_profile</code>
     - <code>still_picture</code>
     - the first value of <code>seq_level_idx</code>
@@ -535,49 +535,49 @@ If a [=CMAF Video Track=] uses the brand <code>av01</code>, it is called a <dfn>
     - <code>color_config</code>
     - <code>initial_presentation_delay_minus_one</code>
 
-When protected, [=CMAF AV1 Tracks=] SHALL use the signaling defined in [[!CMAF]], which in turn relies on [[!CENC]], with the provisions specified in [[#CommonEncryption]].
+<assert>When protected, [=CMAF AV1 Tracks=] SHALL use the signaling defined in [[!CMAF]], which in turn relies on [[!CENC]], with the provisions specified in [[#CommonEncryption]]</assert>.
 
 Common Encryption {#CommonEncryption}
 =========================
 
-[=CMAF AV1 Tracks=] and non-segmented AV1 files MAY be protected. If protected, they SHALL conform to [[!CENC]]. Files SHOULD be protected using the <code>[=cbcs=]</code> protection scheme and MAY be protected using the <code>[=cenc=]</code> protection scheme.
+<assert>[=CMAF AV1 Tracks=] and non-segmented AV1 files MAY be protected</assert>. <assert>If protected, they SHALL conform to [[!CENC]]</assert>. <assert>Files SHOULD be protected using the <code>[=cbcs=]</code> protection scheme</assert> and <assert>MAY be protected using the <code>[=cenc=]</code> protection scheme</assert>.
 
-When the protected scheme <code>[=cenc=]</code> is used, samples SHALL be protected using subsample encryption and SHALL NOT use pattern encryption.
+<assert>When the protected scheme <code>[=cenc=]</code> is used, samples SHALL be protected using subsample encryption</assert> and <assert>SHALL NOT use pattern encryption</assert>.
 
-When the protected scheme <code>[=cbcs=]</code> is used, samples SHALL be protected using subsample encryption and SHALL use pattern encryption. [[!CENC]] recommends that the Block Pattern length be 10, i.e. <code>crypt_byte_block + skip_byte_block = 10</code>, where a Block is of size 16-bytes. In this specification, the combination of <code>crypt_byte_block</code> and <code>skip_byte_block</code> SHALL be one of the following, with the first one being recommended:
-- <code>crypt_byte_block = 1</code> and <code>skip_byte_block = 9</code>,
-- <code>crypt_byte_block = 5</code> and <code>skip_byte_block = 5</code>,
-- <code>crypt_byte_block = 10</code> and <code>skip_byte_block = 0</code>.
+<assert>When the protected scheme <code>[=cbcs=]</code> is used, samples SHALL be protected using subsample encryption</assert> and <assert>SHALL use pattern encryption</assert>. [[!CENC]] recommends that the Block Pattern length be 10, i.e. <code>crypt_byte_block + skip_byte_block = 10</code>, where a Block is of size 16-bytes. In this specification, the combination of <code>crypt_byte_block</code> and <code>skip_byte_block</code> SHALL be one of the following, with the first one being recommended:
+- <assert><code>crypt_byte_block = 1</code> and <code>skip_byte_block = 9</code></assert>,
+- <assert><code>crypt_byte_block = 5</code> and <code>skip_byte_block = 5</code></assert>,
+- <assert><code>crypt_byte_block = 10</code> and <code>skip_byte_block = 0</code></assert>.
 
 
 General Subsample Encryption constraints {#subsample-encryption}
 --------------------------------------
 
 Within protected samples, the following constraints apply:
-- Protected samples SHALL be exactly spanned by one or more contiguous subsamples.
-	- An OBU MAY be spanned by one or more subsamples, especially when it has multiple ranges of protected data. However, as recommended in [[!CENC]], writers SHOULD reduce the number of subsamples as possible. This can be achieved by using a subsample that spans multiple consecutive unprotected OBUs as well as the first unprotected and protected parts of the following protected OBU, if such protected OBU exists.
-	- A large unprotected OBU whose data size is larger than the maximum size of a single [=BytesOfClearData=] field MAY be spanned by multiple subsamples with zero size [=BytesOfProtectedData=].
+- <assert>Protected samples SHALL be exactly spanned by one or more contiguous subsamples</assert>.
+	- <assert>An OBU MAY be spanned by one or more subsamples</assert>, especially when it has multiple ranges of protected data. However, as recommended in [[!CENC]], writers SHOULD reduce the number of subsamples as possible. This can be achieved by using a subsample that spans multiple consecutive unprotected OBUs as well as the first unprotected and protected parts of the following protected OBU, if such protected OBU exists.
+	- <assert>A large unprotected OBU whose data size is larger than the maximum size of a single [=BytesOfClearData=] field MAY be spanned by multiple subsamples with zero size [=BytesOfProtectedData=]</assert>.
 
-- All [=OBU Headers=] and associated [=obu_size=] fields SHALL be unprotected.
-- [=Temporal Delimiter OBUs=], [=Sequence Header OBUs=], and [=Frame Header OBUs=] (including within a [=Frame OBU=]), [=Redundant Frame Header OBUs=] and [=Padding OBUs=] SHALL be unprotected.
-- [=Metadata OBUs=] SHALL NOT be protected.
-- [=Tile Group OBUs=] and [=Frame OBUs=] SHALL be protected. Within [=Tile Group OBUs=] or [=Frame OBUs=], the following applies:
+- <assert>All [=OBU Headers=] and associated [=obu_size=] fields SHALL be unprotected</assert>.
+- <assert>[=Temporal Delimiter OBUs=], [=Sequence Header OBUs=], and [=Frame Header OBUs=] (including within a [=Frame OBU=]), [=Redundant Frame Header OBUs=] and [=Padding OBUs=] SHALL be unprotected</assert>.
+- <assert>[=Metadata OBUs=] SHALL NOT be protected</assert>.
+- <assert>[=Tile Group OBUs=] and [=Frame OBUs=] SHALL be protected</assert>. Within [=Tile Group OBUs=] or [=Frame OBUs=], the following applies:
 	- for the protected scheme <code>[=cbcs=]</code>:
-		- [=BytesOfProtectedData=] SHALL start on the first byte and end on the last byte of the <code>decode_tile</code> structure (including any trailing bits).
+		- <assert>[=BytesOfProtectedData=] SHALL start on the first byte and end on the last byte of the <code>decode_tile</code> structure (including any trailing bits)</assert>.
 
 	    NOTE: As a result of the above, [=BytesOfProtectedData=] is not necessarily a multiple of 16 bytes and partial blocks are included in the [=BytesOfProtectedData=] range, but per [[!CENC]] the data is not be encrypted.
 
-	    - A subsample SHALL be created for each tile, even if its size is less than 16 bytes.
-		- All other parts of [=Tile Group OBUs=] and [=Frame OBUs=] SHALL be unprotected.
+	    - <assert>A subsample SHALL be created for each tile, even if its size is less than 16 bytes</assert>.
+		- <assert>All other parts of [=Tile Group OBUs=] and [=Frame OBUs=] SHALL be unprotected</assert>.
 
 	- for the protected scheme <code>[=cenc=]</code>:
-	    - [=BytesOfProtectedData=] SHALL be a multiple of 16 bytes.
-	    - [=BytesOfProtectedData=] SHALL end on the last byte of the <code>decode_tile</code> structure (including any trailing bits).
-	    - [=BytesOfProtectedData=] SHALL span all complete 16-byte blocks of the <code>decode_tile</code> structure (including any trailing bits).
+	    - <assert>[=BytesOfProtectedData=] SHALL be a multiple of 16 bytes</assert>.
+	    - <assert>[=BytesOfProtectedData=] SHALL end on the last byte of the <code>decode_tile</code> structure (including any trailing bits)</assert>.
+	    - <assert>[=BytesOfProtectedData=] SHALL span all complete 16-byte blocks of the <code>decode_tile</code> structure (including any trailing bits)</assert>.
 
 	    NOTE: As a result of the above, partial blocks are not used and it is possible that [=BytesOfProtectedData=] does not start at the first byte of the <code>decode_tile</code> structure, but some number of bytes following that.
-	    - A subsample SHALL be created for each tile that has a <code>decode_tile</code> structure whose size (including any trailing bits) is larger or equal to 16 bytes. If it is less than 16 bytes, per the rules above, the <code>decode_tile</code> structure is not encrypted and the corresponding bytes SHOULD be included in the [=BytesOfClearData=] field of a surrounding subsample, if any.
-		- All other parts of [=Tile Group OBUs=] and [=Frame OBUs=] SHALL be unprotected.
+	    - <assert>A subsample SHALL be created for each tile that has a <code>decode_tile</code> structure whose size (including any trailing bits) is larger or equal to 16 bytes<assert>. <assert>If it is less than 16 bytes, per the rules above, the <code>decode_tile</code> structure is not encrypted and the corresponding bytes SHOULD be included in the [=BytesOfClearData=] field of a surrounding subsample, if any</assert>.
+		- <assert>All other parts of [=Tile Group OBUs=] and [=Frame OBUs=] SHALL be unprotected</assert>.
 
 Subsample Encryption Illustration {#subsample-encryption-illustration}
 ------------------
@@ -599,25 +599,25 @@ DASH and other applications require defined values for the 'Codecs' parameter sp
 
 All fields following the sample entry 4CC are expressed as double digit decimals, unless indicated otherwise. Leading or trailing zeros cannot be omitted.
 
-The profile parameter value, represented by a single digit decimal, SHALL equal the value of seq_profile in the [=Sequence Header OBU=].
+<assert>The profile parameter value, represented by a single digit decimal, SHALL equal the value of seq_profile in the [=Sequence Header OBU=]</assert>.
 
-The level parameter value SHALL equal the first level value indicated by [=seq_level_idx=] in the [=Sequence Header OBU=].
+<assert>The level parameter value SHALL equal the first level value indicated by [=seq_level_idx=] in the [=Sequence Header OBU=]</assert>.
 
-The tier parameter value SHALL be equal to <code>M</code> when the first [=seq_tier=] value in the [=Sequence Header OBU=] is equal to 0, and <code>H</code> when it is equal to 1.
+<assert>The tier parameter value SHALL be equal to <code>M</code> when the first [=seq_tier=] value in the [=Sequence Header OBU=] is equal to 0, and <code>H</code> when it is equal to 1</assert>.
 
-The bitDepth parameter value SHALL equal the value of BitDepth variable as defined in [[AV1]] derived from the [=Sequence Header OBU=].
+<assert>The bitDepth parameter value SHALL equal the value of BitDepth variable as defined in [[AV1]] derived from the [=Sequence Header OBU=]</assert>.
 
-The monochrome parameter value, represented by a single digit decimal, SHALL equal the value of mono_chrome in the [=Sequence Header OBU=].
+<assert>The monochrome parameter value, represented by a single digit decimal, SHALL equal the value of mono_chrome in the [=Sequence Header OBU=]</assert>.
 
-The chromaSubsampling parameter value, represented by a three-digit decimal, SHALL have its first digit equal to subsampling_x and its second digit equal to subsampling_y. If both subsampling_x and subsampling_y are set to 1, then the third digit SHALL be equal to chroma_sample_position, otherwise it SHALL be set to 0.
+<assert>The chromaSubsampling parameter value, represented by a three-digit decimal, SHALL have its first digit equal to subsampling_x and its second digit equal to subsampling_y</assert>. <assert>If both subsampling_x and subsampling_y are set to 1, then the third digit SHALL be equal to chroma_sample_position, otherwise it SHALL be set to 0</assert>.
 
-The colorPrimaries, transferCharacteristics, matrixCoefficients, and videoFullRangeFlag parameter values SHALL equal the value of matching fields in the [=Sequence Header OBU=], if color_description_present_flag is set to 1, otherwise they SHOULD not be set, defaulting to the values below. The videoFullRangeFlag is represented by a single digit.
+<assert>The colorPrimaries, transferCharacteristics, matrixCoefficients, and videoFullRangeFlag parameter values SHALL equal the value of matching fields in the [=Sequence Header OBU=], if color_description_present_flag is set to 1</assert>, <assert>otherwise they SHOULD not be set, defaulting to the values below</assert>. The videoFullRangeFlag is represented by a single digit.
 
 For example, codecs="av01.0.04M.10.0.112.09.16.09.0" represents AV1 Main Profile, level 3.0, Main tier, 10-bit content, non-monochrome, with 4:2:0 chroma subsampling co-located with (0, 0) luma sample, ITU-R BT.2100 color primaries, ITU-R BT.2100 PQ transfer characteristics, ITU-R BT.2100 YCbCr color matrix, and studio swing representation.
 
-The parameters sample entry 4CC, profile, level, tier, and bitDepth are all mandatory fields. If any of these fields are empty, or not within their allowed range, the processing device SHOULD treat it as an error.
+<assert>The parameters sample entry 4CC, profile, level, tier, and bitDepth are all mandatory fields</assert>. If any of these fields are empty, or not within their allowed range, the processing device SHOULD treat it as an error.
 
-All the other fields (including their leading '.') are optional, mutually inclusive (all or none) fields. If not specified then the values listed in the table below are assumed.
+<assert>All the other fields (including their leading '.') are optional, mutually inclusive (all or none) fields</assert>. If not specified then the values listed in the table below are assumed.
 
 <table class="def">
 <tr>


### PR DESCRIPTION
From the [Bikeshed documentation](https://tabatkins.github.io/bikeshed/#id-gen):
> Bikeshed recognizes a fake element named <assert> for marking "assertions" that tests can refer to. In the generated output, this is converted to a <span> with a unique ID generated from its contents, like issues (described above). This ensures that you have a unique ID that won’t change arbitrarily, but will change when the contents of the assertion change, making it easier to tell when a test might no longer be testing the assertion it points to (because it’s no longer pointing to a valid target at all!).

Wrapping normative statements into assert is not always straightforward, but if we agree on the result, we can then rely on the generated IDs to name test files. 