### PR TITLE
Use two digits for CP, TC, and MC default values

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -624,13 +624,13 @@ For example, codecs="av01.0.04M.10.0.112.09.16.09.0" represents AV1 Main Profile
 <td>chromaSubsampling</td><td>110 (4:2:0)</td>
 </tr>
 <tr>
-<td>colorPrimaries</td><td>1 (ITU-R BT.709)</td>
+<td>colorPrimaries</td><td>01 (ITU-R BT.709)</td>
 </tr>
 <tr>
-<td>transferCharacteristics</td><td>1 (ITU-R BT.709)</td>
+<td>transferCharacteristics</td><td>01 (ITU-R BT.709)</td>
 </tr>
 <tr>
-<td>matrixCoefficients</td><td>1 (ITU-R BT.709)</td>
+<td>matrixCoefficients</td><td>01 (ITU-R BT.709)</td>
 </tr>
 <tr>
 <td>videoFullRangeFlag</td><td>0 (studio swing representation)</td>


### PR DESCRIPTION
Use two digits for the default values of colorPrimaries, transferCharacteristics, and matrixCoefficients.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wantehchang/av1-isobmff/pull/155.html" title="Last updated on Oct 11, 2022, 12:04 AM UTC (94bcbcc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-isobmff/155/12a27a7...wantehchang:94bcbcc.html" title="Last updated on Oct 11, 2022, 12:04 AM UTC (94bcbcc)">Diff</a>