### PR TITLE
Fix version headers in main branch

### DIFF
--- a/v1.0.0.html
+++ b/v1.0.0.html
@@ -1406,7 +1406,7 @@ pre .property::before, pre .property::after {
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
-     <dd><a class="u-url" href="https://aomediacodec.github.io/av1-isobmff/">https://aomediacodec.github.io/av1-isobmff/v1.0.0.html</a>
+     <dd><a class="u-url" href="https://aomediacodec.github.io/av1-isobmff/v1.0.0.html">https://aomediacodec.github.io/av1-isobmff/v1.0.0.html</a>
      <dt>Latest version:
      <dd><a class="u-url" href="https://aomediacodec.github.io/av1-isobmff/">https://aomediacodec.github.io/av1-isobmff/</a>
      <dt>Issue Tracking:

--- a/v1.0.0.html
+++ b/v1.0.0.html
@@ -1406,6 +1406,8 @@ pre .property::before, pre .property::after {
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
+     <dd><a class="u-url" href="https://aomediacodec.github.io/av1-isobmff/">https://aomediacodec.github.io/av1-isobmff/v1.0.0.html</a>
+     <dt>Latest version:
      <dd><a class="u-url" href="https://aomediacodec.github.io/av1-isobmff/">https://aomediacodec.github.io/av1-isobmff/</a>
      <dt>Issue Tracking:
      <dd><a href="https://github.com/AOMediaCodec/av1-isobmff/issues/">GitHub</a>

--- a/v1.1.0.html
+++ b/v1.1.0.html
@@ -1407,6 +1407,8 @@ pre .property::before, pre .property::after {
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
+     <dd><a class="u-url" href="https://aomediacodec.github.io/av1-isobmff/">https://aomediacodec.github.io/av1-isobmff/v1.1.0.html</a>
+     <dt>Latest version:
      <dd><a class="u-url" href="https://aomediacodec.github.io/av1-isobmff/">https://aomediacodec.github.io/av1-isobmff/</a>
      <dt>Issue Tracking:
      <dd><a href="https://github.com/AOMediaCodec/av1-isobmff/issues/">GitHub</a>

--- a/v1.1.0.html
+++ b/v1.1.0.html
@@ -1407,7 +1407,7 @@ pre .property::before, pre .property::after {
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
-     <dd><a class="u-url" href="https://aomediacodec.github.io/av1-isobmff/">https://aomediacodec.github.io/av1-isobmff/v1.1.0.html</a>
+     <dd><a class="u-url" href="https://aomediacodec.github.io/av1-isobmff/v1.1.0.html">https://aomediacodec.github.io/av1-isobmff/v1.1.0.html</a>
      <dt>Latest version:
      <dd><a class="u-url" href="https://aomediacodec.github.io/av1-isobmff/">https://aomediacodec.github.io/av1-isobmff/</a>
      <dt>Issue Tracking:

--- a/v1.2.0.html
+++ b/v1.2.0.html
@@ -1940,7 +1940,9 @@ dfn > a.self-link::before      { content: "#"; }
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
-     </dt><dd><a class="u-url" href="https://aomediacodec.github.io/av1-isobmff/">https://aomediacodec.github.io/av1-isobmff/</a>
+     <dd><a class="u-url" href="https://aomediacodec.github.io/av1-isobmff/v1.2.0.html">https://aomediacodec.github.io/av1-isobmff/v1.2.0.html</a>
+     <dt>Latest version:
+     <dd><a class="u-url" href="https://aomediacodec.github.io/av1-isobmff/">https://aomediacodec.github.io/av1-isobmff/</a>
      </dd><dt>Issue Tracking:
      </dt><dd><a href="https://github.com/AOMediaCodec/av1-isobmff/issues/">GitHub</a>
      </dd><dt class="editor">Editors:


### PR DESCRIPTION
close #160 

If approved, we still need to copy the HTML files for the old versions to the gh-pages branch, as currently the publication tools only publish the main `index.html` file.