### PR TITLE
Remove single quotes from the changelist section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -653,8 +653,8 @@ If any character that is not '.', digits, part of the AV1 4CC, or a tier value i
 Changes since v1.2.0 release {#changelist}
 ==========================================
 - <a href="https://github.com/AOMediaCodec/av1-isobmff/pull/151">Update encryption diagram.</a>
-- <a href="https://github.com/AOMediaCodec/av1-isobmff/pull/152">Remove 'clap' restriction.</a>
+- <a href="https://github.com/AOMediaCodec/av1-isobmff/pull/152">Remove clap restriction.</a>
 - <a href="https://github.com/AOMediaCodec/av1-isobmff/pull/153">Clarify compactness and encryption.</a>
-- <a href="https://github.com/AOMediaCodec/av1-isobmff/pull/156"> Add a NOTE to clarify the 'mdcv' box.</a>
+- <a href="https://github.com/AOMediaCodec/av1-isobmff/pull/156"> Add a NOTE to clarify the mdcv box.</a>
 - <a href="https://github.com/AOMediaCodec/av1-isobmff/pull/162">Clarify requirements on sample entry when encryption is used.</a>
-- <a href="https://github.com/AOMediaCodec/av1-isobmff/pull/167">Clarify the 'colr' box.</a>
+- <a href="https://github.com/AOMediaCodec/av1-isobmff/pull/167">Clarify the colr box.</a>


### PR DESCRIPTION
The single quotes inside a `<a href></a>` element are still treated as an autolink to a CSS property and terminate the link specified in the `<a>` element. Remove all single quotes from the changelist section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wantehchang/av1-isobmff/pull/173.html" title="Last updated on Jun 12, 2023, 7:16 PM UTC (a544b01)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-isobmff/173/e95f6e0...wantehchang:a544b01.html" title="Last updated on Jun 12, 2023, 7:16 PM UTC (a544b01)">Diff</a>